### PR TITLE
graph_panel: provide function to add multiple target at once

### DIFF
--- a/grafonnet/graph_panel.libsonnet
+++ b/grafonnet/graph_panel.libsonnet
@@ -149,5 +149,6 @@
             _nextTarget: nextTarget + 1,
             targets+: [target { refId: std.char(std.codepoint('A') + nextTarget) }],
         },
+        addTargets(targets):: std.foldl(function(p, t) p.addTarget(t), targets, self),
     },
 }

--- a/tests/graph_panel/test.jsonnet
+++ b/tests/graph_panel/test.jsonnet
@@ -41,4 +41,6 @@ local graphPanel = grafana.graphPanel;
     targets: graphPanel.new('with targets')
              .addTarget({ a: 'foo' })
              .addTarget({ b: 'foo' }),
+    multipleTargets: graphPanel.new('with array of targets')
+                     .addTargets([{ a: 'foo' }, { b: 'foo' }]),
 }

--- a/tests/graph_panel/test_compiled.json
+++ b/tests/graph_panel/test_compiled.json
@@ -143,6 +143,83 @@
          }
       ]
    },
+   "multipleTargets": {
+      "aliasColors": { },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "legend": {
+         "alignAsTable": false,
+         "avg": false,
+         "current": false,
+         "max": false,
+         "min": false,
+         "rightSide": false,
+         "show": true,
+         "total": false,
+         "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [ ],
+      "spaceLength": 10,
+      "span": 12,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+         {
+            "a": "foo",
+            "refId": "A"
+         },
+         {
+            "b": "foo",
+            "refId": "B"
+         }
+      ],
+      "thresholds": [ ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "with array of targets",
+      "tooltip": {
+         "shared": true,
+         "sort": 0,
+         "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+         "buckets": null,
+         "mode": "time",
+         "name": null,
+         "show": true,
+         "values": [ ]
+      },
+      "yaxes": [
+         {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+         },
+         {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+         }
+      ]
+   },
    "targets": {
       "aliasColors": { },
       "bars": false,


### PR DESCRIPTION
Useful when targets are generated in advance and stored in an array.