### PR TITLE
add sql target for panels

### DIFF
--- a/grafonnet/grafana.libsonnet
+++ b/grafonnet/grafana.libsonnet
@@ -9,4 +9,5 @@
     graphPanel:: import 'graph_panel.libsonnet',
     singlestat:: import 'singlestat.libsonnet',
     prometheus:: import 'prometheus.libsonnet',
+    sql:: import 'sql.libsonnet',
 }

--- a/grafonnet/sql.libsonnet
+++ b/grafonnet/sql.libsonnet
@@ -2,11 +2,9 @@
     target(
         rawSql,
         datasource=null,
-        refId=null,
         format='time_series',
     ):: {
         [if datasource != null then 'datasource']: datasource,
-        [if refId != null then 'refId']: refId,
         format: format,
         rawSql: rawSql,
     },

--- a/grafonnet/sql.libsonnet
+++ b/grafonnet/sql.libsonnet
@@ -1,0 +1,13 @@
+{
+    target(
+        rawSql,
+        datasource=null,
+        refId=null,
+        format='time_series',
+    ):: {
+        [if datasource != null then 'datasource']: datasource,
+        [if refId != null then 'refId']: refId,
+        format: format,
+        rawSql: rawSql,
+    },
+}

--- a/tests/sql/test.jsonnet
+++ b/tests/sql/test.jsonnet
@@ -1,0 +1,11 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+local sql = grafana.sql;
+
+{
+    basic: sql.target('SELECT now() AS time, 5 AS value'),
+    advanced: sql.target(
+        'SELECT time, value FROM table',
+        datasource='pg_test',
+        format='table',
+    ),
+}

--- a/tests/sql/test_compiled.json
+++ b/tests/sql/test_compiled.json
@@ -1,0 +1,11 @@
+{
+   "advanced": {
+      "datasource": "pg_test",
+      "format": "table",
+      "rawSql": "SELECT time, value FROM table"
+   },
+   "basic": {
+      "format": "time_series",
+      "rawSql": "SELECT now() AS time, 5 AS value"
+   }
+}


### PR DESCRIPTION
This adds a sql target for panels equivalent to the prometheus target, which works for postgres and mysql