### PR TITLE
improve(graph panel) possibility to override Y axes

### DIFF
--- a/grafonnet/graph_panel.libsonnet
+++ b/grafonnet/graph_panel.libsonnet
@@ -167,7 +167,7 @@
         },
         resetYaxes():: self {
             yaxes: [],
-            _nextYaxis:: 0
+            _nextYaxis:: 0,
         },
         _nextYaxis:: 0,
         addYaxis(
@@ -179,9 +179,9 @@
             logBase=1,
             decimals=null,
         ):: self {
-           local nextYaxis = super._nextYaxis,
-           _nextYaxis: nextYaxis + 1,
-           yaxes+: [self.yaxe(format, min, max, label, show, logBase, decimals)],
+            local nextYaxis = super._nextYaxis,
+            _nextYaxis: nextYaxis + 1,
+            yaxes+: [self.yaxe(format, min, max, label, show, logBase, decimals)],
         },
     },
 }

--- a/grafonnet/graph_panel.libsonnet
+++ b/grafonnet/graph_panel.libsonnet
@@ -70,6 +70,7 @@
         legend_sort=null,
         legend_sortDesc=null,
         aliasColors={},
+        value_type='individual'
     ):: {
         title: title,
         span: span,
@@ -121,7 +122,7 @@
         nullPointMode: nullPointMode,
         steppedLine: false,
         tooltip: {
-            value_type: 'individual',
+            value_type: value_type,
             shared: true,
             sort: if sort == 'decreasing' then 2 else if sort == 'increasing' then 1 else sort,
         },
@@ -158,5 +159,29 @@
             targets+: [target { refId: std.char(std.codepoint('A') + nextTarget) }],
         },
         addTargets(targets):: std.foldl(function(p, t) p.addTarget(t), targets, self),
+        _nextSeriesOverride:: 0,
+        addSeriesOverride(override):: self {
+            local nextOverride = super._nextSerieOverride,
+            _nextSeriesOverride: nextOverride + 1,
+            seriesOverrides+: [override],
+        },
+        resetYaxes():: self {
+            yaxes: [],
+            _nextYaxis:: 0
+        },
+        _nextYaxis:: 0,
+        addYaxis(
+            format='short',
+            min=null,
+            max=null,
+            label=null,
+            show=true,
+            logBase=1,
+            decimals=null,
+        ):: self {
+           local nextYaxis = super._nextYaxis,
+           _nextYaxis: nextYaxis + 1,
+           yaxes+: [self.yaxe(format, min, max, label, show, logBase, decimals)],
+        },
     },
 }


### PR DESCRIPTION
Possibility to configure Y axes setup , which is often thingy.

Code might be as

```
        .resetYaxes()
        .addYaxis(format="none", min=0)
        .addYaxis(format="s", min=0)
```

also adds method allowing to override  Series `.addSeriesOverride` , kind of

```

        .addSeriesOverride(
            {
            "alias": "TargetResponseTime_Average",
            "yaxis": 2
            }
        )

```

also possibility in constructor to override `value_type`  rather than have it hardcoded.

assuming that by default folks use default Y axes setup as we had previously 

Example from working case:

```
local grafana = import "lib/grafonnet/grafana.libsonnet";
local graph_panel = grafana.graphPanel;

local grafana_ext = import "lib/sa_grafanonnet/main.libsonnet";

local albMetrics = grafana_ext.metrics.alb;

local metricTarget = grafana_ext.targets.metric;

{
    new(
        datasource = "aws",
    )::
        graph_panel.new(
            title = "RequestCount / Latency",
            ------------- other props -------------
            aliasColors={},
            value_type='cumulative'
        )
        .addTarget(
            metricTarget.new(
                namespace = albMetrics.Namespace,
                metric = albMetrics.Metric_RequestCount,
                refId = "A"
            )
        )
        .addTarget(
            metricTarget.new(
                namespace = albMetrics.Namespace,
                metric = albMetrics.Metric_TargetResponseTime,
                refId = "B"
            )
        )
        .addSeriesOverride(
            {
            "alias": "Latency_Average",
            "yaxis": 2
            }
        )
        .addSeriesOverride(
            {
            "alias": "TargetResponseTime_Average",
            "yaxis": 2
            }
        )
        .resetYaxes()
        .addYaxis(format="none", min=0)
        .addYaxis(format="s", min=0)
}
```