### PR TITLE
[Fix] Adding support for passing builtIn in annotation

### DIFF
--- a/grafonnet/annotation.libsonnet
+++ b/grafonnet/annotation.libsonnet
@@ -18,6 +18,7 @@
     iconColor='rgba(255, 96, 96, 1)',
     tags=[],
     type='tags',
+    builtIn=null,
   )::
     {
       datasource: datasource,
@@ -29,5 +30,6 @@
       showIn: 0,
       tags: tags,
       type: type,
+      [if builtIn != null then 'builtIn']: builtIn,
     },
 }

--- a/tests/annotation/test.jsonnet
+++ b/tests/annotation/test.jsonnet
@@ -13,5 +13,6 @@ local annotation = grafana.annotation;
     iconColor='rgba(25, 6, 6, 2)',
     tags=['foo'],
     type='rows',
+    builtIn=1,
   ),
 }

--- a/tests/annotation/test_compiled.json
+++ b/tests/annotation/test_compiled.json
@@ -1,5 +1,6 @@
 {
    "advanced": {
+      "builtIn": 1,
       "datasource": "advDS",
       "enable": false,
       "expr": "advExpr",


### PR DESCRIPTION
Currently `builtIn` is there in `default` for `annotation` but there is no provision to pass while creating a new `grafana.annotation.datasource`.

This implementation will help to pass `builtIn` and will not affect if not passed.