### PR TITLE
Prevent "unknown operand" messages from tests.sh

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -6,7 +6,7 @@ x=0
 for i in `find . -name '*.jsonnet' -or -name '*.libsonnet'`
 do
     t="Formating $i..."
-    if [[ $1 == "update" ]]; then
+    if [[ "$1" == "update" ]]; then
         jsonnet fmt -i $jsonnet_fmt $i
     fi
     if jsonnet fmt --test $jsonnet_fmt $i;
@@ -32,7 +32,7 @@ do
         continue
     fi
 
-    if [[ $1 == "update" ]]; then cp $json $json_e; fi
+    if [[ "$1" == "update" ]]; then cp $json $json_e; fi
 
     t="Checking $i..."
     if diff -urt $json $json_e


### PR DESCRIPTION
This change updates the tests.sh script to prevent messages like "sh: update: unknown operand" when run without parameters.

Without quotes around `$1`, the shell tries to interpret `if [[ == "update" ]]; then` and fails. With quotes, the empty string is on the left hand side of the `==` operator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grafana/grafonnet-lib/88)
<!-- Reviewable:end -->
