### PR TITLE
Add 'sort' parameter to query template.

### DIFF
--- a/grafonnet/template.libsonnet
+++ b/grafonnet/template.libsonnet
@@ -12,6 +12,7 @@
     refresh='never',
     includeAll=false,
     multi=false,
+    sort=0,
   )::
     {
       allValue: allValues,
@@ -26,7 +27,7 @@
       query: query,
       refresh: $.refresh(refresh),
       regex: regex,
-      sort: 0,
+      sort: sort,
       tagValuesQuery: tagValuesQuery,
       tags: [],
       tagsQuery: '',

--- a/tests/template/query.jsonnet
+++ b/tests/template/query.jsonnet
@@ -14,6 +14,7 @@ local template = grafana.template;
     current='bar',
     hide='value',
     includeAll=true,
+    sort=2,
     multi=true,
   ),
   refresh: [

--- a/tests/template/query_compiled.json
+++ b/tests/template/query_compiled.json
@@ -15,7 +15,7 @@
       "query": "newtest-query",
       "refresh": 0,
       "regex": "([a-z+])",
-      "sort": 0,
+      "sort": 2,
       "tagValuesQuery": "tvquery",
       "tags": [ ],
       "tagsQuery": "",


### PR DESCRIPTION
This change adds a new optional sort parameter to the query template. This parameter allows users to specify the sort order of values returned by a template query. This is helpful for predictable value locations, especially as lists grow longer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grafana/grafonnet-lib/89)
<!-- Reviewable:end -->
