### PR TITLE
Graph series

### DIFF
--- a/grafonnet/graph_panel.libsonnet
+++ b/grafonnet/graph_panel.libsonnet
@@ -13,6 +13,8 @@
    * @param format Unit of the Y axes
    * @param min Min of the Y axes
    * @param max Max of the Y axes
+   * @param x_axis_mode X axis mode, one of [time, series, histogram]
+   * @param x_axis_values Chosen value of series, one of [avg, min, max, total, count]
    * @param lines Display lines, boolean
    * @param points Display points, boolean
    * @param bars Display bars, boolean
@@ -44,6 +46,8 @@
     format='short',
     min=null,
     max=null,
+    x_axis_mode='time',
+    x_axis_values='total',
     lines=true,
     datasource=null,
     points=false,
@@ -88,9 +92,9 @@
     ],
     xaxis: {
       show: show_xaxis,
-      mode: 'time',
+      mode: x_axis_mode,
       name: null,
-      values: [],
+      values: [x_axis_values],
       buckets: null,
     },
     lines: lines,

--- a/grafonnet/graph_panel.libsonnet
+++ b/grafonnet/graph_panel.libsonnet
@@ -94,7 +94,7 @@
       show: show_xaxis,
       mode: x_axis_mode,
       name: null,
-      values: [x_axis_values],
+      values: if x_axis_mode == 'series' then [x_axis_values] else [],
       buckets: null,
     },
     lines: lines,

--- a/tests/graph_panel/test.jsonnet
+++ b/tests/graph_panel/test.jsonnet
@@ -38,6 +38,8 @@ local graphPanel = grafana.graphPanel;
     legend_hideEmpty=true,
     legend_hideZero=true,
   ),
+  graph_series: graphPanel.new('series', span=12, x_axis_mode='series',),
+  graph_series_custom_value: graphPanel.new('series', span=12, x_axis_mode='series', x_axis_values='current',),
   targets: graphPanel.new('with targets', span=12)
            .addTarget({ a: 'foo' })
            .addTarget({ b: 'foo' }),

--- a/tests/graph_panel/test_compiled.json
+++ b/tests/graph_panel/test_compiled.json
@@ -218,6 +218,148 @@
          }
       ]
    },
+   "graph_series": {
+      "aliasColors": { },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "legend": {
+         "alignAsTable": false,
+         "avg": false,
+         "current": false,
+         "max": false,
+         "min": false,
+         "rightSide": false,
+         "show": true,
+         "total": false,
+         "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [ ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [ ],
+      "spaceLength": 10,
+      "span": 12,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [ ],
+      "thresholds": [ ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "series",
+      "tooltip": {
+         "shared": true,
+         "sort": 0,
+         "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+         "buckets": null,
+         "mode": "series",
+         "name": null,
+         "show": true,
+         "values": [
+            "total"
+         ]
+      },
+      "yaxes": [
+         {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+         },
+         {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+         }
+      ]
+   },
+   "graph_series_custom_value": {
+      "aliasColors": { },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "legend": {
+         "alignAsTable": false,
+         "avg": false,
+         "current": false,
+         "max": false,
+         "min": false,
+         "rightSide": false,
+         "show": true,
+         "total": false,
+         "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [ ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [ ],
+      "spaceLength": 10,
+      "span": 12,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [ ],
+      "thresholds": [ ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "series",
+      "tooltip": {
+         "shared": true,
+         "sort": 0,
+         "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+         "buckets": null,
+         "mode": "series",
+         "name": null,
+         "show": true,
+         "values": [
+            "current"
+         ]
+      },
+      "yaxes": [
+         {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+         },
+         {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+         }
+      ]
+   },
    "legendSort": {
       "aliasColors": { },
       "bars": false,


### PR DESCRIPTION
Add possibility to create graphs based on series, not time

Default input and result:

```
graphPanel.new( )

$ jsonnet -J vendor exchanges.jsonnet | grep xaxis -A +7
               "xaxis": {
                  "buckets": null,
                  "mode": "time",
                  "name": null,
                  "show": true,
                  "values": [ ]
               },
```

Series input and result:

```
graphPanel.new(
...
      x_axis_mode='series',
    )

$ jsonnet -J vendor exchanges.jsonnet | grep xaxis -A +7
               "xaxis": {
                  "buckets": null,
                  "mode": "series",
                  "name": null,
                  "show": true,
                  "values": [
                     "total"
                  ]
```

Series and values input and result:

```
graphPanel.new(
...
      x_axis_values='current',
      x_axis_mode='series',
    )

$ jsonnet -J vendor exchanges.jsonnet | grep xaxis -A +7
               "xaxis": {
                  "buckets": null,
                  "mode": "series",
                  "name": null,
                  "show": true,
                  "values": [
                     "current"
                  ]
```