### PR TITLE
Pointradius is now parametric

### DIFF
--- a/grafonnet/graph_panel.libsonnet
+++ b/grafonnet/graph_panel.libsonnet
@@ -15,6 +15,7 @@
    * @param max Max of the Y axes
    * @param lines Display lines, boolean
    * @param points Display points, boolean
+   * @param pointradius Radius of the points, allowed values are 0.5 or [1 ... 10] with step 1
    * @param bars Display bars, boolean
    * @param dashes Display line as dashes
    * @param stack Stack values
@@ -47,6 +48,7 @@
     lines=true,
     datasource=null,
     points=false,
+    pointradius=5,
     bars=false,
     height=null,
     nullPointMode='null',
@@ -100,7 +102,7 @@
     dashLength: 10,
     spaceLength: 10,
     points: points,
-    pointradius: 5,
+    pointradius: pointradius,
     bars: bars,
     stack: stack,
     percentage: false,


### PR DESCRIPTION
Fixes https://github.com/grafana/grafonnet-lib/issues/87

I made pointradius parametric and default it to 5 (the original value) not to break existing dashboards.
The tests passes.
I added the param in the comments to but not being a pure integer I just explained the allowed values.
Please let me know if you want me to change anything else.