### PR TITLE
Add addConditions function that allows passing of an array of conditions

### DIFF
--- a/grafonnet/graph_panel.libsonnet
+++ b/grafonnet/graph_panel.libsonnet
@@ -208,6 +208,7 @@
       addCondition(condition):: self {
         _conditions+: [condition],
       },
+      addConditions(conditions):: std.foldl(function(p, c) p.addCondition(c), conditions, it),
     },
   },
 }

--- a/tests/graph_panel/test.jsonnet
+++ b/tests/graph_panel/test.jsonnet
@@ -59,4 +59,7 @@ local graphPanel = grafana.graphPanel;
   alerts: graphPanel.new('with alerts', span=12)
           .addAlert('name of alert')
           .addCondition([]),
+  alertsWithMultipleConditions: graphPanel.new('with alert conditions as an array', span=12)
+                                .addAlert('name of alert')
+                                .addConditions([{ c1: 'params' }, { c2: 'params' }]),
 }

--- a/tests/graph_panel/test_compiled.json
+++ b/tests/graph_panel/test_compiled.json
@@ -156,6 +156,91 @@
          }
       ]
    },
+   "alertsWithMultipleConditions": {
+      "alert": {
+         "conditions": [
+            {
+               "c1": "params"
+            },
+            {
+               "c2": "params"
+            }
+         ],
+         "executionErrorState": "alerting",
+         "frequency": "60s",
+         "handler": 1,
+         "name": "name of alert",
+         "noDataState": "no_data",
+         "notifications": [ ]
+      },
+      "aliasColors": { },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "legend": {
+         "alignAsTable": false,
+         "avg": false,
+         "current": false,
+         "max": false,
+         "min": false,
+         "rightSide": false,
+         "show": true,
+         "total": false,
+         "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [ ],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [ ],
+      "spaceLength": 10,
+      "span": 12,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [ ],
+      "thresholds": [ ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "with alert conditions as an array",
+      "tooltip": {
+         "shared": true,
+         "sort": 0,
+         "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+         "buckets": null,
+         "mode": "time",
+         "name": null,
+         "show": true,
+         "values": [ ]
+      },
+      "yaxes": [
+         {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+         },
+         {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+         }
+      ]
+   },
    "aliasColors": {
       "aliasColors": {
          "busy": "#bf1b00",


### PR DESCRIPTION
Use case:

```
local grafana = import 'grafonnet/grafana.libsonnet';

local service = [
  grafana.graphPanel.new(
    metric.name,
    format=metric.format,
    datasource='...',
  )
  .addTarget(
    grafana.prometheus.target(metric.query)
  )
  .addAlert(
      metric.name + ' alert',
      executionErrorState='keep_state',
  )
  .addConditions(metric.conditions)
  for metric in [
    {
      name: '...',
      format: 'none',
      query: '...',
      conditions: [
        grafana.alertCondition.new(evaluatorParams=[5], queryTimeStart='10m'),
        grafana.alertCondition.new(evaluatorParams=[5], queryTimeStart='5m', evaluatorType='lt')
      ]
    },
    {
      // more metrics
    },
  ]
];

{
  dashboard: grafana.dashboard.new('Alerts', editable=true, schemaVersion=16).addPanels(
    service
  ),
  overwrite: true,
}
```
