### PR TITLE
Fixes #106 - support elastic search targets.

### DIFF
--- a/grafonnet/elasticsearch.libsonnet
+++ b/grafonnet/elasticsearch.libsonnet
@@ -1,0 +1,38 @@
+{
+  target(
+    query,
+    id=null,
+    datasource=null,
+    metrics=[{
+      field: "value",
+      id: null,
+      type: "percentiles",
+      settings: {
+        percents: [
+          "90",
+        ],
+      },
+    }],
+    bucketAggs=[{
+      field: "timestamp",
+      id: null,
+      type: "date_histogram",
+      settings: {
+          interval: "1s",
+          min_doc_count: 0,
+          trimEdges: 0
+      },
+    }],
+    timeField,
+    alias=null,
+  ):: {
+    [if datasource != null then 'datasource']: datasource,
+    query: query,
+    id: id,
+    timeField: timeField,
+    bucketAggs: bucketAggs,
+    metrics: metrics,
+    alias: alias
+    // TODO: generate bucket ids
+  }
+}

--- a/grafonnet/grafana.libsonnet
+++ b/grafonnet/grafana.libsonnet
@@ -15,4 +15,5 @@
   graphite:: import 'graphite.libsonnet',
   alertCondition:: import 'alert_condition.libsonnet',
   cloudwatch:: import 'cloudwatch.libsonnet',
+  elasticsearch:: import 'elasticsearch.libsonnet',
 }

--- a/tests/elasticsearch/test.jsonnet
+++ b/tests/elasticsearch/test.jsonnet
@@ -1,0 +1,48 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+local elastic = grafana.elasticsearch;
+
+{
+  // todo basic
+  basic: elastic.target('up', timeField="@timestamp"),
+  advanced: elastic.target(
+       query="metric.source: iostat AND metric.type: blockdev_request_size_KB",
+       timeField="metric.begin",
+       alias="{{metric.device}}",
+       metrics=[
+        {
+          id: "1",
+          field: "metric.value",
+          settings: {
+            percents: [
+              "90",
+            ]
+          },
+          type: "percentiles"
+        }
+      ],
+      bucketAggs=[
+      {
+        id: "2",
+        field: "metric.device",
+        type: "terms",
+        settings: {
+          order: "desc",
+          size: "10",
+          min_doc_count: 1,
+          orderBy: "_term"
+        },
+      },
+      {
+        id: "3",
+        field: "@timestamp",
+        type: "date_histogram",
+        settings: {
+            interval: "1s",
+            min_doc_count: 0,
+            trimEdges: 0
+        },
+      }
+      ],
+  ),
+  // todo heatmap
+}

--- a/tests/elasticsearch/test_compiled.json
+++ b/tests/elasticsearch/test_compiled.json
@@ -1,0 +1,73 @@
+{
+   "advanced": {
+      "alias": "{{metric.device}}",
+      "bucketAggs": [
+         {
+            "field": "metric.device",
+            "id": "2",
+            "settings": {
+               "min_doc_count": 1,
+               "order": "desc",
+               "orderBy": "_term",
+               "size": "10"
+            },
+            "type": "terms"
+         },
+         {
+            "field": "@timestamp",
+            "id": "3",
+            "settings": {
+               "interval": "1s",
+               "min_doc_count": 0,
+               "trimEdges": 0
+            },
+            "type": "date_histogram"
+         }
+      ],
+      "id": null,
+      "metrics": [
+         {
+            "field": "metric.value",
+            "id": "1",
+            "settings": {
+               "percents": [
+                  "90"
+               ]
+            },
+            "type": "percentiles"
+         }
+      ],
+      "query": "metric.source: iostat AND metric.type: blockdev_request_size_KB",
+      "timeField": "metric.begin"
+   },
+   "basic": {
+      "alias": null,
+      "bucketAggs": [
+         {
+            "field": "timestamp",
+            "id": null,
+            "settings": {
+               "interval": "1s",
+               "min_doc_count": 0,
+               "trimEdges": 0
+            },
+            "type": "date_histogram"
+         }
+      ],
+      "id": null,
+      "metrics": [
+         {
+            "field": "value",
+            "id": null,
+            "settings": {
+               "percents": [
+                  "90"
+               ]
+            },
+            "type": "percentiles"
+         }
+      ],
+      "query": "up",
+      "timeField": "@timestamp"
+   }
+}


### PR DESCRIPTION
The following PR will support ES basic functionality to be able to create ES targets.
it adds:
- target functionality.
- target tests. 

Fix: #106 

@roidelapluie PTAL