### PR TITLE
Add a small example with Prometheus and addPanels

### DIFF
--- a/examples/prometheus.jsonnet
+++ b/examples/prometheus.jsonnet
@@ -1,0 +1,93 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local template = grafana.template;
+local singlestat = grafana.singlestat;
+local graphPanel = grafana.graphPanel;
+local prometheus = grafana.prometheus;
+
+local buildInfo =
+  singlestat.new(
+    title='Version',
+    datasource='Prometheus',
+    format='none',
+    valueName='name',
+  ).addTarget(
+    prometheus.target(
+      'prometheus_build_info{instance="$instance"}',
+      legendFormat='{{ version }}',
+    )
+  );
+
+local systemLoad =
+  singlestat.new(
+    title='5m system load',
+    datasource='Prometheus',
+    format='none',
+    valueName='current',
+    decimals=2,
+    sparklineShow=true,
+    colorValue=true,
+    thresholds='4,6',
+  ).addTarget(
+    prometheus.target(
+      'node_load5{instance="$instance"}',
+    )
+  );
+
+local networkTraffic =
+  graphPanel.new(
+    title='Network traffic on eth0',
+    datasource='Prometheus',
+    linewidth=2,
+    format='Bps',
+    aliasColors={
+      Rx: 'light-green',
+      Tx: 'light-red',
+    },
+  ).addTarget(
+    prometheus.target(
+      'rate(node_network_receive_bytes_total{instance="$instance",device="eth0"}[1m])',
+      legendFormat='Rx',
+    )
+  ).addTarget(
+    prometheus.target(
+      'irate(node_network_transmit_bytes_total{instance="$instance",device="eth0"}[1m]) * (-1)',
+      legendFormat='Tx',
+    )
+  );
+
+dashboard.new(
+  'Prometheus test',
+  tags=['prometheus'],
+  schemaVersion=18,
+  editable=true,
+  time_from='now-1h',
+  refresh='1m',
+)
+.addTemplate(
+  template.datasource(
+    'PROMETHEUS_DS',
+    'prometheus',
+    'Prometheus',
+    hide='label',
+  )
+)
+.addTemplate(
+  template.new(
+    'instance',
+    '$PROMETHEUS_DS',
+    'label_values(prometheus_build_info, instance)',
+    label='Instance',
+    refresh='time',
+  )
+)
+
+.addPanels(
+  [
+    buildInfo { gridPos: { h: 4, w: 3, x: 0, y: 0 } },
+
+    systemLoad { gridPos: { h: 4, w: 4, x: 3, y: 0 } },
+
+    networkTraffic { gridPos: { h: 8, w: 7, x: 0, y: 4 } },
+  ]
+)

--- a/examples/prometheus_compiled.json
+++ b/examples/prometheus_compiled.json
@@ -1,0 +1,348 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [ ]
+   },
+   "editable": true,
+   "gnetId": null,
+   "graphTooltip": 0,
+   "hideControls": false,
+   "id": null,
+   "links": [ ],
+   "panels": [
+      {
+         "cacheTimeout": null,
+         "colorBackground": false,
+         "colorValue": false,
+         "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+         ],
+         "datasource": "Prometheus",
+         "format": "none",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 0,
+            "y": 0
+         },
+         "id": 2,
+         "interval": null,
+         "links": [ ],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "prometheus_build_info{instance=\"$instance\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{ version }}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "",
+         "title": "Version",
+         "type": "singlestat",
+         "valueFontSize": "80%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "name"
+      },
+      {
+         "cacheTimeout": null,
+         "colorBackground": false,
+         "colorValue": true,
+         "colors": [
+            "#299c46",
+            "rgba(237, 129, 40, 0.89)",
+            "#d44a3a"
+         ],
+         "datasource": "Prometheus",
+         "decimals": 2,
+         "format": "none",
+         "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+         },
+         "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 3,
+            "y": 0
+         },
+         "id": 3,
+         "interval": null,
+         "links": [ ],
+         "mappingType": 1,
+         "mappingTypes": [
+            {
+               "name": "value to text",
+               "value": 1
+            },
+            {
+               "name": "range to text",
+               "value": 2
+            }
+         ],
+         "maxDataPoints": 100,
+         "nullPointMode": "connected",
+         "nullText": null,
+         "postfix": "",
+         "postfixFontSize": "50%",
+         "prefix": "",
+         "prefixFontSize": "50%",
+         "rangeMaps": [
+            {
+               "from": "null",
+               "text": "N/A",
+               "to": "null"
+            }
+         ],
+         "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+         },
+         "tableColumn": "",
+         "targets": [
+            {
+               "expr": "node_load5{instance=\"$instance\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": "4,6",
+         "title": "5m system load",
+         "type": "singlestat",
+         "valueFontSize": "80%",
+         "valueMaps": [
+            {
+               "op": "=",
+               "text": "N/A",
+               "value": "null"
+            }
+         ],
+         "valueName": "current"
+      },
+      {
+         "aliasColors": {
+            "Rx": "light-green",
+            "Tx": "light-red"
+         },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "Prometheus",
+         "fill": 1,
+         "gridPos": {
+            "h": 8,
+            "w": 7,
+            "x": 0,
+            "y": 4
+         },
+         "id": 4,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 2,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "rate(node_network_receive_bytes_total{instance=\"$instance\",device=\"eth0\"}[1m])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Rx",
+               "refId": "A"
+            },
+            {
+               "expr": "irate(node_network_transmit_bytes_total{instance=\"$instance\",device=\"eth0\"}[1m]) * (-1)",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "Tx",
+               "refId": "B"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Network traffic on eth0",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "Bps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "Bps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      }
+   ],
+   "refresh": "1m",
+   "rows": [ ],
+   "schemaVersion": 18,
+   "style": "dark",
+   "tags": [
+      "prometheus"
+   ],
+   "templating": {
+      "list": [
+         {
+            "current": {
+               "text": "Prometheus",
+               "value": "Prometheus"
+            },
+            "hide": 1,
+            "label": null,
+            "name": "PROMETHEUS_DS",
+            "options": [ ],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "type": "datasource"
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "$PROMETHEUS_DS",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Instance",
+            "multi": false,
+            "name": "instance",
+            "options": [ ],
+            "query": "label_values(prometheus_build_info, instance)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         }
+      ]
+   },
+   "time": {
+      "from": "now-1h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "browser",
+   "title": "Prometheus test",
+   "version": 0
+}


### PR DESCRIPTION
Add another small example showcasing the use of Prometheus datasource and, especially, `addPanels` which does not seem to be documented or used that widely, however, is crucial when building dashboards with more than 10-15 panels. 