### PR TITLE
add hide to prometheus target

### DIFF
--- a/grafonnet/prometheus.libsonnet
+++ b/grafonnet/prometheus.libsonnet
@@ -7,7 +7,9 @@
     datasource=null,
     interval=null,
     instant=null,
+    hide=null,
   ):: {
+    [if hide != null then 'hide']: hide,
     [if datasource != null then 'datasource']: datasource,
     expr: expr,
     format: format,


### PR DESCRIPTION
This pr supports adding `hide=true` for prometheus targets. Tested this on Grafana version v6.3.5