### PR TITLE
table: Add a method to easily hide a column

### DIFF
--- a/grafonnet/graph_panel.libsonnet
+++ b/grafonnet/graph_panel.libsonnet
@@ -181,17 +181,12 @@
       targets+: [target { refId: std.char(std.codepoint('A') + nextTarget) }],
     },
     addTargets(targets):: std.foldl(function(p, t) p.addTarget(t), targets, self),
-    _nextSeriesOverride:: 0,
     addSeriesOverride(override):: self {
-      local nextOverride = super._nextSerieOverride,
-      _nextSeriesOverride: nextOverride + 1,
       seriesOverrides+: [override],
     },
     resetYaxes():: self {
       yaxes: [],
-      _nextYaxis:: 0,
     },
-    _nextYaxis:: 0,
     addYaxis(
       format='short',
       min=null,
@@ -201,8 +196,6 @@
       logBase=1,
       decimals=null,
     ):: self {
-      local nextYaxis = super._nextYaxis,
-      _nextYaxis: nextYaxis + 1,
       yaxes+: [self.yaxe(format, min, max, label, show, logBase, decimals)],
     },
     addAlert(

--- a/grafonnet/table_panel.libsonnet
+++ b/grafonnet/table_panel.libsonnet
@@ -81,5 +81,12 @@
       styles+: [style],
       columns+: [column_],
     },
+    hideColumn(field):: self {
+      styles+: [{
+        alias: field,
+        pattern: field,
+        type: 'hidden',
+      }],
+    },
   },
 }

--- a/tests.sh
+++ b/tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 jsonnet_fmt='-n 2 --max-blank-lines 2 --sort-imports --string-style s --comment-style s'
 x=0

--- a/tests/table_panel/test.jsonnet
+++ b/tests/table_panel/test.jsonnet
@@ -41,6 +41,6 @@ local tablePanel = grafana.tablePanel;
     'test',
     span=12,
   ).
-  hideColumn('Time').
-  hideColumn('Space')
+    hideColumn('Time').
+    hideColumn('Space'),
 }

--- a/tests/table_panel/test.jsonnet
+++ b/tests/table_panel/test.jsonnet
@@ -37,4 +37,10 @@ local tablePanel = grafana.tablePanel;
       tablePanel.new('with batch targets', span=12)
       .addTargets([{ a: 'foo' }, { b: 'foo' }]),
     ],
+  hideColumns: tablePanel.new(
+    'test',
+    span=12,
+  ).
+  hideColumn('Time').
+  hideColumn('Space')
 }

--- a/tests/table_panel/test_compiled.json
+++ b/tests/table_panel/test_compiled.json
@@ -42,6 +42,27 @@
       "transform": "table",
       "type": "table"
    },
+   "hideColumns": {
+      "columns": [ ],
+      "datasource": null,
+      "span": 12,
+      "styles": [
+         {
+            "alias": "Time",
+            "pattern": "Time",
+            "type": "hidden"
+         },
+         {
+            "alias": "Space",
+            "pattern": "Space",
+            "type": "hidden"
+         }
+      ],
+      "targets": [ ],
+      "title": "test",
+      "transform": "table",
+      "type": "table"
+   },
    "targets": [
       {
          "columns": [ ],


### PR DESCRIPTION
Make it easy to hide a particular column in a table without manually constructing a style for it by providing a method, `hideColumn` that takes a column name.

While we're here, clean up some unnecessary variables in `graph_panel.libsonnet` and update tests.sh to use bash, since it uses non-posix shell features (`[[`).