### PR TITLE
Add timeFrom and timeShift support for table and graph

### DIFF
--- a/examples/k8s_cluster_summary_compiled.json
+++ b/examples/k8s_cluster_summary_compiled.json
@@ -348,6 +348,8 @@
                      "refId": "A"
                   }
                ],
+               "timeFrom": null,
+               "timeShift": null,
                "title": "Node Info",
                "type": "table"
             }
@@ -1307,6 +1309,8 @@
                      "refId": "A"
                   }
                ],
+               "timeFrom": null,
+               "timeShift": null,
                "title": "Deployment Replicas - Up To Date",
                "type": "table"
             }
@@ -2278,6 +2282,8 @@
                      "refId": "A"
                   }
                ],
+               "timeFrom": null,
+               "timeShift": null,
                "title": "Container Failed to Start",
                "type": "table"
             }

--- a/grafonnet/graph_panel.libsonnet
+++ b/grafonnet/graph_panel.libsonnet
@@ -97,7 +97,9 @@
     transparent=false,
     value_type='individual',
     shared_tooltip=true,
-    percentage=false
+    percentage=false,
+    time_from=null,
+    time_shift=null,
   ):: {
     title: title,
     [if span != null then 'span']: span,
@@ -154,8 +156,8 @@
       shared: shared_tooltip,
       sort: if sort == 'decreasing' then 2 else if sort == 'increasing' then 1 else sort,
     },
-    timeFrom: null,
-    timeShift: null,
+    timeFrom: time_from,
+    timeShift: time_shift,
     [if transparent == true then 'transparent']: transparent,
     aliasColors: aliasColors,
     repeat: repeat,

--- a/grafonnet/table_panel.libsonnet
+++ b/grafonnet/table_panel.libsonnet
@@ -27,7 +27,9 @@
     transform=null,
     transparent=false,
     columns=[],
-    sort=null
+    sort=null,
+    time_from=null,
+    time_shift=null,
   ):: {
     type: 'table',
     title: title,
@@ -39,6 +41,8 @@
     ],
     styles: styles,
     columns: columns,
+    timeFrom: time_from,
+    timeShift: time_shift,
     [if sort != null then 'sort']: sort,
     [if description != null then 'description']: description,
     [if transform != null then 'transform']: transform,

--- a/tests/table_panel/test.jsonnet
+++ b/tests/table_panel/test.jsonnet
@@ -33,7 +33,9 @@ local tablePanel = grafana.tablePanel;
     sort={
       col: 1,
       desc: true,
-    }
+    },
+    time_from='24h',
+    time_shift='1h',
   ),
   targets:
     [

--- a/tests/table_panel/test_compiled.json
+++ b/tests/table_panel/test_compiled.json
@@ -32,6 +32,8 @@
          }
       ],
       "targets": [ ],
+      "timeFrom": "24h",
+      "timeShift": "1h",
       "title": "test",
       "transform": "table",
       "transparent": true,
@@ -43,6 +45,8 @@
       "span": 12,
       "styles": [ ],
       "targets": [ ],
+      "timeFrom": null,
+      "timeShift": null,
       "title": "test",
       "type": "table"
    },
@@ -63,6 +67,8 @@
          }
       ],
       "targets": [ ],
+      "timeFrom": null,
+      "timeShift": null,
       "title": "test",
       "type": "table"
    },
@@ -82,6 +88,8 @@
                "refId": "B"
             }
          ],
+         "timeFrom": null,
+         "timeShift": null,
          "title": "with targets",
          "type": "table"
       },
@@ -100,6 +108,8 @@
                "refId": "\u0083"
             }
          ],
+         "timeFrom": null,
+         "timeShift": null,
          "title": "with batch targets",
          "type": "table"
       }


### PR DESCRIPTION
Add `timeFrom` and `timeShift` for table and graph.
Tested `timeFrom` for table on my local deployment.