### PR TITLE
feat: add tableColumn to singlestat

### DIFF
--- a/grafonnet/singlestat.libsonnet
+++ b/grafonnet/singlestat.libsonnet
@@ -52,6 +52,7 @@
     gaugeThresholdLabels=false,
     timeFrom=null,
     links=[],
+    tableColumn='',
   )::
     {
       [if height != null then 'height']: height,
@@ -119,7 +120,7 @@
         lineColor: sparklineLineColor,
         show: sparklineShow,
       },
-      tableColumn: '',
+      tableColumn: tableColumn,
       _nextTarget:: 0,
       addTarget(target):: self {
         local nextTarget = super._nextTarget,


### PR DESCRIPTION
This adds the tableColumn parameter on the single stat panel. This allows you to control which field vault you want displayed if you choice to have the data format as table 