### PR TITLE
Add InfluxDB query editor support

### DIFF
--- a/grafonnet/influxdb.libsonnet
+++ b/grafonnet/influxdb.libsonnet
@@ -1,58 +1,4 @@
 {
-  local it = self,
-
-  /**
-   * Return an InfluxDB query tag condition
-   *
-   * @param key Left value
-   * @param operator Comparison operator
-   * @param value Right value
-   * @param condition AND/OR logical condition in respect to previous tag conditions
-   *
-   * @return Query tag condition
-   */
-  tag(
-    key,
-    operator,
-    value,
-    condition=null
-  ):: {
-    key: key,
-    operator: operator,
-    value: value,
-    [if condition != null then 'condition']: condition,
-  },
-
-  /**
-   * Return an InfluxDB converter (aggregation, selector, etc.)
-   *
-   * @param type Converter type (aggregation, selector, etc.)
-   * @param params List of converter params
-   *
-   * @return Query selected value converter
-   */
-
-  converter(
-    type,
-    params=[]
-  ):: {
-    type: type,
-    params: params,
-  },
-
-  /**
-   * Return an InfluxDB selection (part of 'Select' statement)
-   *
-   * @param field Selected field name
-   * @param converters List of value converters
-   *
-   * @return Query selection
-   */
-  selection(
-    field='value',
-    converters=[it.converter('mean')],
-  ):: [it.converter('field', [field])] + converters,
-
   /**
    * Return an InfluxDB Target
    *
@@ -67,8 +13,6 @@
    *
    * @param policy Tagged query 'From' policy
    * @param measurement Tagged query 'From' measurement
-   * @param where List of 'Where' query tag conditions
-   * @param selections List of 'Select' field selections with their converters (aggregation, selector, etc.)
    * @param group_time 'Group by' time condition (if set to null, do not groups by time)
    * @param group_tags 'Group by' tags list
    * @param fill 'Group by' missing values fill mode (works only with 'Group by time()')
@@ -87,14 +31,15 @@
 
     policy='default',
     measurement=null,
-    where=[],
-    selections=[it.selection()],
+
     group_time='$__interval',
     group_tags=[],
     fill='none',
 
     resultFormat='time_series',
   ):: {
+    local it = self,
+
     [if alias != null then 'alias']: alias,
     [if datasource != null then 'datasource']: datasource,
 
@@ -104,16 +49,53 @@
 
     policy: policy,
     [if measurement != null then 'measurement']: measurement,
-    tags: where,
-    select: selections,
+    tags: [],
+    select: [],
     groupBy:
       if group_time != null then
-        [it.converter('time', [group_time])] +
-        [it.converter('tag', [tag_name]) for tag_name in group_tags] +
-        [it.converter('fill', [fill])]
+        [{ type: 'time', params: [group_time] }] +
+        [{ type: 'tag', params: [tag_name] } for tag_name in group_tags] +
+        [{ type: 'fill', params: [fill] }]
       else
-        [it.converter('tag', [tag_name]) for tag_name in group_tags],
+        [{ type: 'tag', params: [tag_name] } for tag_name in group_tags],
 
     resultFormat: resultFormat,
+
+    where(key, operator, value, condition=null):: self {
+      /*
+       * Adds query tag condition ('Where' section)
+       */
+      tags:
+        if std.length(it.tags) == 0 then
+          [{ key: key, operator: operator, value: value }]
+        else
+          it.tags + [{
+            key: key,
+            operator: operator,
+            value: value,
+            condition: if condition == null then 'AND' else condition,
+          }],
+    },
+
+    selectField(value):: self {
+      /*
+       * Adds InfluxDB selection ('field(value)' part of 'Select' statement)
+       */
+      select+: [[{ params: [value], type: 'field' }]],
+    },
+
+    addConverter(type, params=[]):: self {
+      /*
+       * Appends converter (aggregation, selector, etc.) to last added selection
+       */
+      local len = std.length(it.select),
+      select:
+        if len == 1 then
+          [it.select[0] + [{ params: params, type: type }]]
+        else if len > 1 then
+          it.select[0:(len - 1)] + [it.select[len - 1] + [{ params: params, type: type }]]
+        else
+          [],
+    },
   },
 }

--- a/grafonnet/influxdb.libsonnet
+++ b/grafonnet/influxdb.libsonnet
@@ -1,29 +1,119 @@
 {
+  local it = self,
+
+  /**
+   * Return an InfluxDB query tag condition
+   *
+   * @param key Left value
+   * @param operator Comparison operator
+   * @param value Right value
+   * @param condition AND/OR logical condition in respect to previous tag conditions
+   *
+   * @return Query tag condition
+   */
+  tag(
+    key,
+    operator,
+    value,
+    condition=null
+  ):: {
+    key: key,
+    operator: operator,
+    value: value,
+    [if condition != null then 'condition']: condition,
+  },
+
+  /**
+   * Return an InfluxDB converter (aggregation, selector, etc.)
+   *
+   * @param type Converter type (aggregation, selector, etc.)
+   * @param params List of converter params
+   *
+   * @return Query selected value converter
+   */
+
+  converter(
+    type,
+    params=[]
+  ):: {
+    type: type,
+    params: params,
+  },
+
+  /**
+   * Return an InfluxDB selection (part of 'Select' statement)
+   *
+   * @param field Selected field name
+   * @param converters List of value converters
+   *
+   * @return Query selection
+   */
+  selection(
+    field='value',
+    converters=[it.converter('mean')],
+  ):: [it.converter('field', [field])] + converters,
+
   /**
    * Return an InfluxDB Target
    *
    * @name influxdb.target
    *
    * @param query Raw InfluxQL statement
-   * @param alias Alias By pattern
+   *
+   * @param alias 'Alias By' pattern
    * @param datasource Datasource
-   * @param rawQuery En/Disable raw query mode
+   *
+   * @param rawQuery Enable/disable raw query mode
+   *
+   * @param policy Tagged query 'From' policy
+   * @param measurement Tagged query 'From' measurement
+   * @param where List of 'Where' query tag conditions
+   * @param selections List of 'Select' field selections with their converters (aggregation, selector, etc.)
+   * @param group_time 'Group by' time condition (if set to null, do not groups by time)
+   * @param group_tags 'Group by' tags list
+   * @param fill 'Group by' missing values fill mode (works only with 'Group by time()')
+   *
    * @param resultFormat Format results as 'Time series' or 'Table'
-
+   *
    * @return Panel target
    */
   target(
-    query,
+    query=null,
+
     alias=null,
     datasource=null,
-    rawQuery=true,
+
+    rawQuery=null,
+
+    policy='default',
+    measurement=null,
+    where=[],
+    selections=[it.selection()],
+    group_time='$__interval',
+    group_tags=[],
+    fill='none',
+
     resultFormat='time_series',
   ):: {
-    query: query,
-    rawQuery: rawQuery,
-    resultFormat: resultFormat,
-
     [if alias != null then 'alias']: alias,
     [if datasource != null then 'datasource']: datasource,
+
+    [if query != null then 'query']: query,
+    [if rawQuery != null then 'rawQuery']: rawQuery,
+    [if rawQuery == null && query != null then 'rawQuery']: true,
+
+    policy: policy,
+    [if measurement != null then 'measurement']: measurement,
+    tags: where,
+    select: selections,
+    groupBy:
+      if group_time != null then
+        [it.converter('time', [group_time])] +
+        [it.converter('tag', [tag_name]) for tag_name in group_tags] +
+        [it.converter('fill', [fill])]
+      else
+        [it.converter('tag', [tag_name]) for tag_name in group_tags],
+
+    resultFormat: resultFormat,
   },
 }

--- a/tests/influxdb/test.jsonnet
+++ b/tests/influxdb/test.jsonnet
@@ -2,7 +2,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
 local influxdb = grafana.influxdb;
 
 {
-  basic: influxdb.target(
+  rawQuery_basic: influxdb.target(
     |||
       SELECT mean("my_field")
       FROM my_meas
@@ -10,7 +10,7 @@ local influxdb = grafana.influxdb;
       GROUP BY time($__interval)
     |||
   ),
-  advanced: influxdb.target(
+  rawQuery_advanced: influxdb.target(
     |||
       SELECT non_negative_derivative(mean("bytes_recv"), 1s) *8
       FROM "net" WHERE ("host" =~ /^my_host.tld\.net$/ AND "interface" =~ /^eth0$/)
@@ -19,5 +19,28 @@ local influxdb = grafana.influxdb;
     |||,
     alias='$tag_host',
     datasource='telegraf',
+  ),
+  tagged_query_basic: influxdb.target(
+    measurement='ram',
+    where=([influxdb.tag('metric_name', '=', 'ram_usage')]),
+  ),
+  tagged_query_advanced: influxdb.target(
+    alias='$tag_host',
+    policy='ret_30w',
+    measurement='mem',
+    where=[
+      influxdb.tag('host', '=', 'msk'),
+      influxdb.tag('instance', '=~', '/storage/'),
+    ],
+    selections=[
+      influxdb.selection('used_percent', [influxdb.converter('percentile', [95])]),
+    ],
+    group_tags=['host'],
+    fill=0,
+  ),
+  tagged_query_without_group_by_time: influxdb.target(
+    measurement='ram',
+    where=([influxdb.tag('metric_name', '=', 'ram_usage')]),
+    group_time=null
   ),
 }

--- a/tests/influxdb/test.jsonnet
+++ b/tests/influxdb/test.jsonnet
@@ -2,45 +2,63 @@ local grafana = import 'grafonnet/grafana.libsonnet';
 local influxdb = grafana.influxdb;
 
 {
-  rawQuery_basic: influxdb.target(
-    |||
-      SELECT mean("my_field")
-      FROM my_meas
-      WHERE $timeFilter
-      GROUP BY time($__interval)
-    |||
-  ),
-  rawQuery_advanced: influxdb.target(
-    |||
-      SELECT non_negative_derivative(mean("bytes_recv"), 1s) *8
-      FROM "net" WHERE ("host" =~ /^my_host.tld\.net$/ AND "interface" =~ /^eth0$/)
-      AND $timeFilter
-      GROUP BY time($__interval), "host" fill(none)
-    |||,
-    alias='$tag_host',
-    datasource='telegraf',
-  ),
-  tagged_query_basic: influxdb.target(
-    measurement='ram',
-    where=([influxdb.tag('metric_name', '=', 'ram_usage')]),
-  ),
-  tagged_query_advanced: influxdb.target(
-    alias='$tag_host',
-    policy='ret_30w',
-    measurement='mem',
-    where=[
-      influxdb.tag('host', '=', 'msk'),
-      influxdb.tag('instance', '=~', '/storage/'),
-    ],
-    selections=[
-      influxdb.selection('used_percent', [influxdb.converter('percentile', [95])]),
-    ],
-    group_tags=['host'],
-    fill=0,
-  ),
-  tagged_query_without_group_by_time: influxdb.target(
-    measurement='ram',
-    where=([influxdb.tag('metric_name', '=', 'ram_usage')]),
-    group_time=null
-  ),
+  rawQuery_basic:
+    influxdb.target(
+      |||
+        SELECT mean("my_field")
+        FROM my_meas
+        WHERE $timeFilter
+        GROUP BY time($__interval)
+      |||
+    ),
+
+  rawQuery_advanced:
+    influxdb.target(
+      |||
+        SELECT non_negative_derivative(mean("bytes_recv"), 1s) *8
+        FROM "net" WHERE ("host" =~ /^my_host.tld\.net$/ AND "interface" =~ /^eth0$/)
+        AND $timeFilter
+        GROUP BY time($__interval), "host" fill(none)
+      |||,
+      alias='$tag_host',
+      datasource='telegraf',
+    ),
+
+  tagged_query_basic:
+    influxdb.target(
+      measurement='ram',
+    )
+    .where('metric_name', '=', 'ram_usage')
+    .selectField('value').addConverter('mean'),
+
+  tagged_query_advanced:
+    influxdb.target(
+      alias='$tag_host',
+      policy='ret_30w',
+      measurement='mem',
+      fill=0,
+      group_tags=['host'],
+    )
+    .where('host', '=', 'msk')
+    .where('instance', '=~', '/storage/')
+    .selectField('used_percent').addConverter('percentile', [95]),
+
+  tagged_query_without_group_by_time:
+    influxdb.target(
+      measurement='ram',
+      group_time=null
+    ).where('metric_name', '=', 'ram_usage')
+    .selectField('value').addConverter('mean'),
+
+  tagged_query_multiple_selections:
+    influxdb.target(
+      alias='$tag_host',
+      policy='ret_30w',
+      measurement='mem',
+      fill=0,
+      group_tags=['instance', 'zone'],
+    )
+    .where('host', '=', 'msk')
+    .selectField('used_percent').addConverter('percentile', [95])
+    .selectField('used_bytes').addConverter('mean').addConverter('math', ' / 1000'),
 }

--- a/tests/influxdb/test_compiled.json
+++ b/tests/influxdb/test_compiled.json
@@ -20,20 +20,7 @@
       "query": "SELECT non_negative_derivative(mean(\"bytes_recv\"), 1s) *8\nFROM \"net\" WHERE (\"host\" =~ /^my_host.tld\\.net$/ AND \"interface\" =~ /^eth0$/)\nAND $timeFilter\nGROUP BY time($__interval), \"host\" fill(none)\n",
       "rawQuery": true,
       "resultFormat": "time_series",
-      "select": [
-         [
-            {
-               "params": [
-                  "value"
-               ],
-               "type": "field"
-            },
-            {
-               "params": [ ],
-               "type": "mean"
-            }
-         ]
-      ],
+      "select": [ ],
       "tags": [ ]
    },
    "rawQuery_basic": {
@@ -55,20 +42,7 @@
       "query": "SELECT mean(\"my_field\")\nFROM my_meas\nWHERE $timeFilter\nGROUP BY time($__interval)\n",
       "rawQuery": true,
       "resultFormat": "time_series",
-      "select": [
-         [
-            {
-               "params": [
-                  "value"
-               ],
-               "type": "field"
-            },
-            {
-               "params": [ ],
-               "type": "mean"
-            }
-         ]
-      ],
+      "select": [ ],
       "tags": [ ]
    },
    "tagged_query_advanced": {
@@ -119,6 +93,7 @@
             "value": "msk"
          },
          {
+            "condition": "AND",
             "key": "instance",
             "operator": "=~",
             "value": "/storage/"
@@ -162,6 +137,77 @@
             "key": "metric_name",
             "operator": "=",
             "value": "ram_usage"
+         }
+      ]
+   },
+   "tagged_query_multiple_selections": {
+      "alias": "$tag_host",
+      "groupBy": [
+         {
+            "params": [
+               "$__interval"
+            ],
+            "type": "time"
+         },
+         {
+            "params": [
+               "instance"
+            ],
+            "type": "tag"
+         },
+         {
+            "params": [
+               "zone"
+            ],
+            "type": "tag"
+         },
+         {
+            "params": [
+               0
+            ],
+            "type": "fill"
+         }
+      ],
+      "measurement": "mem",
+      "policy": "ret_30w",
+      "resultFormat": "time_series",
+      "select": [
+         [
+            {
+               "params": [
+                  "used_percent"
+               ],
+               "type": "field"
+            },
+            {
+               "params": [
+                  95
+               ],
+               "type": "percentile"
+            }
+         ],
+         [
+            {
+               "params": [
+                  "used_bytes"
+               ],
+               "type": "field"
+            },
+            {
+               "params": [ ],
+               "type": "mean"
+            },
+            {
+               "params": " / 1000",
+               "type": "math"
+            }
+         ]
+      ],
+      "tags": [
+         {
+            "key": "host",
+            "operator": "=",
+            "value": "msk"
          }
       ]
    },

--- a/tests/influxdb/test_compiled.json
+++ b/tests/influxdb/test_compiled.json
@@ -1,14 +1,195 @@
 {
-   "advanced": {
+   "rawQuery_advanced": {
       "alias": "$tag_host",
       "datasource": "telegraf",
+      "groupBy": [
+         {
+            "params": [
+               "$__interval"
+            ],
+            "type": "time"
+         },
+         {
+            "params": [
+               "none"
+            ],
+            "type": "fill"
+         }
+      ],
+      "policy": "default",
       "query": "SELECT non_negative_derivative(mean(\"bytes_recv\"), 1s) *8\nFROM \"net\" WHERE (\"host\" =~ /^my_host.tld\\.net$/ AND \"interface\" =~ /^eth0$/)\nAND $timeFilter\nGROUP BY time($__interval), \"host\" fill(none)\n",
       "rawQuery": true,
-      "resultFormat": "time_series"
+      "resultFormat": "time_series",
+      "select": [
+         [
+            {
+               "params": [
+                  "value"
+               ],
+               "type": "field"
+            },
+            {
+               "params": [ ],
+               "type": "mean"
+            }
+         ]
+      ],
+      "tags": [ ]
    },
-   "basic": {
+   "rawQuery_basic": {
+      "groupBy": [
+         {
+            "params": [
+               "$__interval"
+            ],
+            "type": "time"
+         },
+         {
+            "params": [
+               "none"
+            ],
+            "type": "fill"
+         }
+      ],
+      "policy": "default",
       "query": "SELECT mean(\"my_field\")\nFROM my_meas\nWHERE $timeFilter\nGROUP BY time($__interval)\n",
       "rawQuery": true,
-      "resultFormat": "time_series"
+      "resultFormat": "time_series",
+      "select": [
+         [
+            {
+               "params": [
+                  "value"
+               ],
+               "type": "field"
+            },
+            {
+               "params": [ ],
+               "type": "mean"
+            }
+         ]
+      ],
+      "tags": [ ]
+   },
+   "tagged_query_advanced": {
+      "alias": "$tag_host",
+      "groupBy": [
+         {
+            "params": [
+               "$__interval"
+            ],
+            "type": "time"
+         },
+         {
+            "params": [
+               "host"
+            ],
+            "type": "tag"
+         },
+         {
+            "params": [
+               0
+            ],
+            "type": "fill"
+         }
+      ],
+      "measurement": "mem",
+      "policy": "ret_30w",
+      "resultFormat": "time_series",
+      "select": [
+         [
+            {
+               "params": [
+                  "used_percent"
+               ],
+               "type": "field"
+            },
+            {
+               "params": [
+                  95
+               ],
+               "type": "percentile"
+            }
+         ]
+      ],
+      "tags": [
+         {
+            "key": "host",
+            "operator": "=",
+            "value": "msk"
+         },
+         {
+            "key": "instance",
+            "operator": "=~",
+            "value": "/storage/"
+         }
+      ]
+   },
+   "tagged_query_basic": {
+      "groupBy": [
+         {
+            "params": [
+               "$__interval"
+            ],
+            "type": "time"
+         },
+         {
+            "params": [
+               "none"
+            ],
+            "type": "fill"
+         }
+      ],
+      "measurement": "ram",
+      "policy": "default",
+      "resultFormat": "time_series",
+      "select": [
+         [
+            {
+               "params": [
+                  "value"
+               ],
+               "type": "field"
+            },
+            {
+               "params": [ ],
+               "type": "mean"
+            }
+         ]
+      ],
+      "tags": [
+         {
+            "key": "metric_name",
+            "operator": "=",
+            "value": "ram_usage"
+         }
+      ]
+   },
+   "tagged_query_without_group_by_time": {
+      "groupBy": [ ],
+      "measurement": "ram",
+      "policy": "default",
+      "resultFormat": "time_series",
+      "select": [
+         [
+            {
+               "params": [
+                  "value"
+               ],
+               "type": "field"
+            },
+            {
+               "params": [ ],
+               "type": "mean"
+            }
+         ]
+      ],
+      "tags": [
+         {
+            "key": "metric_name",
+            "operator": "=",
+            "value": "ram_usage"
+         }
+      ]
    }
 }


### PR DESCRIPTION
Add InfluxDB query editor support in InfluxDB target. New InfluxDB editor query replaces old-style rawQuery in default target settings, similar to Grafana UI editor defaults.

Closes #177