### PR TITLE
Status Panel (by Vonage) support

### DIFF
--- a/grafonnet/grafana.libsonnet
+++ b/grafonnet/grafana.libsonnet
@@ -19,4 +19,5 @@
   elasticsearch:: import 'elasticsearch.libsonnet',
   heatmapPanel:: import 'heatmap_panel.libsonnet',
   gauge:: import 'gauge.libsonnet',
+  vonageStatusPanel:: import 'vonage-status-panel.libsonnet',
 }

--- a/grafonnet/vonage-status-panel.libsonnet
+++ b/grafonnet/vonage-status-panel.libsonnet
@@ -1,0 +1,132 @@
+{
+  /**
+   * Returns status panel metric display settings.
+   * It is required to handle target result in status panel visualization
+   *
+   * @param alias Alias
+   * @param aggregation Multiple data points aggregation (Last, Mean, etc)
+   * @param valueRegex The regex which will decide the part of the value to be displayed
+   * @param url Clickable metric URL
+   *
+   * @param handlerType Handler type (available handlers: Number Threshold, String Threshold, Date Threshold, Disable Criteria, Text Only)
+   * @param displayType Display type (available types: Regular or Annotation)
+   * @param units Units of measure (Number Threshold only)
+   * @param decimals Decimals precision for numbers (Number Threshold only)
+   * @param dateFormat Date/Time format (Date Threshold only)
+   *
+   * @param crit Critical threshold value. Get numbers, strings or dates (Threshold handlers only)
+   * @param warn Warning threshold value. Get numbers, strings or dates (Threshold handlers only)
+   * @param showAlways Show the metric also if threshold is not satisfied (Threshold handlers only)
+   * @param disabledValue The exact value which will make panel to be displayed as disabled (Disable Criteria only)
+   *
+   * @return A json that represents a metric display part of status panel target
+   */
+  display(
+    alias=null,
+    aggregation='Last',
+    valueRegex='',
+    url=null,
+
+    handlerType='Number Threshold',
+    displayType='Regular',
+    units='none',
+    decimals=2,
+    dateFormat='YYYY-MM-DD HH:mm:ss',
+
+    crit=null,
+    warn=null,
+    showAlways=false,
+    disabledValue=null,
+  ):: {
+    [if alias != null then 'alias']: alias,
+    aggregation: aggregation,
+    [if valueRegex != '' then 'valueDisplayRegex']: valueRegex,
+    [if url != null then 'url']: url,
+    valueHandler: handlerType,
+    displayType: displayType,
+    [if crit != null then 'crit']: crit,
+    [if warn != null then 'warn']: warn,
+    display: showAlways,
+    units: units,
+    decimals: decimals,
+    dateFormat: dateFormat,
+    [if disabledValue != null then 'disabledValue']: disabledValue,
+  },
+
+  /**
+   * Returns a new status panel.
+   * It requires Status Panel plugin in grafana, which can be installed from
+   * https://grafana.com/grafana/plugins/vonage-status-panel.
+   *
+   * @param title The title of the status panel.
+   * @param span Width of the panel
+   * @param datasource Datasource
+   * @param description Panel description
+   * @param transparent Boolean (default: false) If set to true the panel will be transparent
+   *
+   * @param panelTitle Panel title
+   * @param removePrefix A prefix to remove from the name
+   * @param maxAlertNumber Max alert number to show in the panel
+   *
+   * @param flipCard Flip card on/off (true or false)
+   * @param flipTime Flip interval
+   *
+   * @param colorMode Threshold coloring mode (available modes: Panel, Metric, Disabled)
+   * @param colors Dictionary with "ok", "warn", "crit", "disable" keys and corresponding panel colors
+   *
+   * @param isGrayOnNoData Use 'Disable' color if no data
+   * @param isIgnoreOKColors Ignore color in OK state
+   * @param isHideAlertsOnDisable Hide alerts in Disabled state
+   *
+   * @return A json that represents a status panel
+   */
+  new(
+    title,
+    span=null,
+    datasource=null,
+    description='',
+    transparent=null,
+
+    panelTitle=null,
+    removePrefix='',
+    maxAlertNumber=null,
+
+    flipCard=false,
+    flipTime=5,
+
+    colorMode='Panel',
+    colors={
+      crit: 'rgba(245, 54, 54, 0.9)',
+      disable: 'rgba(128, 128, 128, 0.9)',
+      ok: 'rgba(50, 128, 45, 0.9)',
+      warn: 'rgba(237, 129, 40, 0.9)',
+    },
+
+    isGrayOnNoData=false,
+    isIgnoreOKColors=false,
+    isHideAlertsOnDisable=false,
+  ):: {
+    title: title,
+    type: 'vonage-status-panel',
+    [if span != null then 'span']: span,
+    [if datasource != null then 'datasource']: datasource,
+    [if description != null then 'description']: description,
+    [if transparent != null then 'transparent']: transparent,
+    [if panelTitle != null then 'clusterName']: panelTitle,
+    [if removePrefix != '' then 'namePrefix']: removePrefix,
+    [if maxAlertNumber != null then 'maxAlertNumber']: maxAlertNumber,
+    flipCard: flipCard,
+    flipTime: flipTime,
+    colorMode: colorMode,
+    colors: colors,
+    isGrayOnNoData: isGrayOnNoData,
+    isIgnoreOKColors: isIgnoreOKColors,
+    isHideAlertsOnDisable: isHideAlertsOnDisable,
+    _nextTarget:: 0,
+    addTarget(target, display={}):: self {
+      local nextTarget = super._nextTarget,
+      _nextTarget: nextTarget + 1,
+      targets+: [target { refId: std.char(std.codepoint('A') + nextTarget) } + display],
+    },
+  },
+}

--- a/tests/vonage_status_panel/test.jsonnet
+++ b/tests/vonage_status_panel/test.jsonnet
@@ -1,0 +1,35 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+local vonageStatusPanel = grafana.vonageStatusPanel;
+
+{
+  basic: vonageStatusPanel.new(
+    'test'
+  ),
+  advanced: vonageStatusPanel.new(
+    title='test',
+    panelTitle='My panel',
+    removePrefix='My',
+    maxAlertNumber=5,
+    colorMode='Metric',
+    colors={
+      crit: 'rgba(245, 54, 54, 0.9)',
+      disable: '#C4162A',
+      ok: 'rgba(50, 128, 45, 0.9)',
+      warn: 'rgba(237, 129, 40, 0.9)',
+    },
+    isGrayOnNoData=true
+  ),
+  target: vonageStatusPanel.new(
+    title='test'
+  ).addTarget(
+    { alias: 'alias' },
+    vonageStatusPanel.display(
+      alias='alias',
+      handlerType='Number Threshold',
+      decimals=3,
+      crit=1,
+      warn=0.5,
+      showAlways=true
+    )
+  ),
+}

--- a/tests/vonage_status_panel/test_compiled.json
+++ b/tests/vonage_status_panel/test_compiled.json
@@ -1,0 +1,71 @@
+{
+   "advanced": {
+      "clusterName": "My panel",
+      "colorMode": "Metric",
+      "colors": {
+         "crit": "rgba(245, 54, 54, 0.9)",
+         "disable": "#C4162A",
+         "ok": "rgba(50, 128, 45, 0.9)",
+         "warn": "rgba(237, 129, 40, 0.9)"
+      },
+      "description": "",
+      "flipCard": false,
+      "flipTime": 5,
+      "isGrayOnNoData": true,
+      "isHideAlertsOnDisable": false,
+      "isIgnoreOKColors": false,
+      "maxAlertNumber": 5,
+      "namePrefix": "My",
+      "title": "test",
+      "type": "vonage-status-panel"
+   },
+   "basic": {
+      "colorMode": "Panel",
+      "colors": {
+         "crit": "rgba(245, 54, 54, 0.9)",
+         "disable": "rgba(128, 128, 128, 0.9)",
+         "ok": "rgba(50, 128, 45, 0.9)",
+         "warn": "rgba(237, 129, 40, 0.9)"
+      },
+      "description": "",
+      "flipCard": false,
+      "flipTime": 5,
+      "isGrayOnNoData": false,
+      "isHideAlertsOnDisable": false,
+      "isIgnoreOKColors": false,
+      "title": "test",
+      "type": "vonage-status-panel"
+   },
+   "target": {
+      "colorMode": "Panel",
+      "colors": {
+         "crit": "rgba(245, 54, 54, 0.9)",
+         "disable": "rgba(128, 128, 128, 0.9)",
+         "ok": "rgba(50, 128, 45, 0.9)",
+         "warn": "rgba(237, 129, 40, 0.9)"
+      },
+      "description": "",
+      "flipCard": false,
+      "flipTime": 5,
+      "isGrayOnNoData": false,
+      "isHideAlertsOnDisable": false,
+      "isIgnoreOKColors": false,
+      "targets": [
+         {
+            "aggregation": "Last",
+            "alias": "alias",
+            "crit": 1,
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "decimals": 3,
+            "display": true,
+            "displayType": "Regular",
+            "refId": "A",
+            "units": "none",
+            "valueHandler": "Number Threshold",
+            "warn": 0.5
+         }
+      ],
+      "title": "test",
+      "type": "vonage-status-panel"
+   }
+}


### PR DESCRIPTION
[Status Panel](https://grafana.com/grafana/plugins/vonage-status-panel) by [Vonage](https://grafana.com/orgs/vonage) is a Grafana panel plugin meant to be used as a centralized view for the status of component in a glance. This pull request adds Status Panel support

Closes #181