### PR TITLE
Suggested approach to external plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ difficult. Therefore, into the future, Grafonnet will limit itself to features
 that are present within Grafana without the use of additional plugins.
 
 Fortunately, Grafonnet uses Jsonnet, and adding support for your own plugins
-is easy. See the [Adding support for plugins](#adding-plugins-to-grafonnet)
+is easy. See the "[Adding Plugins to Grafonnet](#adding-plugins-to-grafonnet)"
 section for details of how to do this.
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ If we use [Jsonnet Bundler](https://github.com/jsonnet-bundler/jsonnet-bundler)
 alongside our new library, we can have it import both the code for all the
 plugins we depend upon, and Grafonnet itself, in one seamless step.
 
+See a full list of public 'plugins' for Grafonnet [here](plugins.md).
+
 [brew]:https://brew.sh/
 [jsonnet]:http://jsonnet.org/
 [jsonnetgh]:https://github.com/google/jsonnet

--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ components that you can use and reuse for multiple dashboards.
 
 ![screenshot](screenshot.png)
 
+## Contribution Guidelines
+Grafana has a wide ecosystem of plugins, and there is no reason why Grafonnet
+could not be used to deploy dashboards containing resources provided by
+these plugins.
+
+However, *maintaining* Grafonnet, with all these plugins, would be difficult.
+Therefore, into the future, Grafonnet will limit itself to features that are
+present within Grafana without the use of additional plugins.
+
+Fortunately, Grafonnet uses Jsonnet, and adding support for your own plugins
+is easy. See the [Adding support for plugins](#adding-plugins-to-grafonnet)
+section for details of how to do this.
+
 ## Getting started
 
 ### Prerequisites
@@ -200,6 +213,43 @@ dashboard.new(
 
 Find more examples in the [examples](examples/) directory.
 
+## Adding Plugins to Grafonnet
+
+As stated above, Grafonnet will be limiting itself to supporting features
+that exist within core Grafana itself (without additional plugins).
+
+However, the power of Jsonnet makes it easy to work with extensions to
+Grafonnet library. If we maintain the Grafonnet code for the external
+plugin separately from Grafonnet itself, we can create a `grafonnet`
+object to use within our Jsonnet code that contains all the features we
+need, like so:
+
+```jsonnet
+local grafonnet = (import 'grafonnet-lib/grafana.libsonnet')
+                + (import 'my-plugin-lib/my-plugin.libsonnet');
+{
+  ....our dashboards
+}
+```
+
+Moreover, we can add this to our own library, e.g. `my-grafonnet/grafonnet.libsonnet`:
+
+```jsonnet
+(import 'grafonnet-lib/grafana.libsonnet')
++ (import 'my-plugin-lib/my-plugin.libsonnet');
+```
+From now on, we can access this like so:
+
+```jsonnet
+local grafonnet = (import 'my-grafonnet/grafonnet.libsonnet');
+{
+  ....our dashboards
+}
+```
+
+If we use [Jsonnet Bundler](https://github.com/jsonnet-bundler/jsonnet-bundler)
+alongside our new library, we can have it import both the code for all the
+plugins we depend upon, and Grafonnet itself, in one seamless step.
 
 [brew]:https://brew.sh/
 [jsonnet]:http://jsonnet.org/

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Grafana has a wide ecosystem of plugins, and there is no reason why Grafonnet
 could not be used to deploy dashboards containing resources provided by
 these plugins.
 
-However, *maintaining* Grafonnet, with all these plugins, would be difficult.
-Therefore, into the future, Grafonnet will limit itself to features that are
-present within Grafana without the use of additional plugins.
+However, *maintaining* Grafonnet, with support for all these plugins, would be
+difficult. Therefore, into the future, Grafonnet will limit itself to features
+that are present within Grafana without the use of additional plugins.
 
 Fortunately, Grafonnet uses Jsonnet, and adding support for your own plugins
 is easy. See the [Adding support for plugins](#adding-plugins-to-grafonnet)

--- a/plugins.md
+++ b/plugins.md
@@ -1,0 +1,20 @@
+# Grafonnet Plugins
+
+Jsonnet makes it easy to patch an existing library. Therefore,
+although the base Grafonnet only supports core Grafana features,
+it is easy to extend it with additional 'plugins', which are
+simply a directories of libsonnet files, and can be used like
+so:
+
+```jsonnet
+local grafonnet = (import 'grafonnet-lib/grafana.libsonnet')
+                + (import 'my-plugin-lib/my-plugin.libsonnet');
+{
+  ....our dashboards
+}
+```
+
+## Plugin List
+
+(the idea of plugins is new. Please submit a PR to add your plugin
+here).

--- a/plugins.md
+++ b/plugins.md
@@ -1,6 +1,6 @@
 # Grafonnet Plugins
 
-Jsonnet makes it easy to patch an existing library. Therefore,
+Jsonnet makes it easy to patch an existing library.
 although the base Grafonnet only supports core Grafana features,
 it is easy to extend it with additional 'plugins', which are
 simply a directories of libsonnet files, and can be used like

--- a/plugins.md
+++ b/plugins.md
@@ -3,7 +3,7 @@
 Jsonnet makes it easy to patch an existing library.
 Although Grafonnet only supports core Grafana features,
 it is easy to extend it with additional 'plugins', which are
-simply a directories of libsonnet files, and can be used like
+simply directories of libsonnet files, and can be used like
 so:
 
 ```jsonnet

--- a/plugins.md
+++ b/plugins.md
@@ -1,7 +1,7 @@
 # Grafonnet Plugins
 
 Jsonnet makes it easy to patch an existing library.
-although the base Grafonnet only supports core Grafana features,
+Although Grafonnet only supports core Grafana features,
 it is easy to extend it with additional 'plugins', which are
 simply a directories of libsonnet files, and can be used like
 so:


### PR DESCRIPTION
Grafonnet currently lacks a boundary as to what features it will, and what features it won't support/accept.

This PR offers a suggestion. It makes sense to limit Grafonnet to features that are present within Vanilla Grafana, and add support for any other resources using Jsonnet patching. The outcome in terms of programming is the same, yet we can cover maintenance of Grafonnet libraries in a more distributed manner.