### PR TITLE
Fix x_axis_buckets value when histogram mode

### DIFF
--- a/grafonnet/graph_panel.libsonnet
+++ b/grafonnet/graph_panel.libsonnet
@@ -128,7 +128,7 @@
       mode: x_axis_mode,
       name: null,
       values: if x_axis_mode == 'series' then [x_axis_values] else [],
-      buckets: if x_axis_mode == 'histogram' then [x_axis_buckets] else null,
+      buckets: if x_axis_mode == 'histogram' then x_axis_buckets else null,
       [if x_axis_min != null then 'min']: x_axis_min,
       [if x_axis_max != null then 'max']: x_axis_max,
     },


### PR DESCRIPTION
Hello !
I found a problem with the value of `x_axis_buckets`.
I use `Grafana v6.7.2 (423a25fc32)` and I found that by updating with the Grafana user interface, it directly set the value without an array.

With no value (auto), I have:
```json
"xaxis": {
    "buckets": null,
    "mode": "histogram",
    "name": null,
    "show": true,
    "values": []
}
```

With value `20`, I have:
```json
"xaxis": {
    "buckets": 20,
    "mode": "histogram",
    "name": null,
    "show": true,
    "values": []
}
```