### PR TITLE
Generate API Docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ jobs:
           name: unit tests
           command: make test
       - run:
+          name: api-docs
+          command: make gen-api-docs
+      - run:
           name: docs
           command: docker run --rm -u $UID -it -p 8000:8000 -v $PWD:/docs squidfunk/mkdocs-material build
       - add_ssh_keys

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 site
+docs/api-docs.md
 *_test_output.json
 e2e/node_modules
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,6 @@ gen-api-docs: # Generate api-docs.md from source code comments.
 		-u $$UID \
 		-v $$PWD:$$PWD \
 		-w $$PWD \
-		trotttrotttrott/jsonnetdoc:4f806c6 \
+		trotttrotttrott/jsonnetdoc:219e41b \
 		grafonnet --markdown \
 		> docs/api-docs.md

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,8 @@ test-update:  # Run all unit tests while copying test_output.json to compiled.js
 
 gen-api-docs: # Generate api-docs.md from source code comments.
 	@docker run --rm \
-		-u $$UID \
-		-v $$PWD:$$PWD \
 		-w $$PWD \
+		-v $$PWD:$$PWD \
 		trotttrotttrott/jsonnetdoc:219e41b \
 		grafonnet --markdown \
 		> docs/api-docs.md

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,28 @@
-help:        # Show this message.
+help:         # Show this message.
 	@echo "\nAvailable Targets:\n"
 	@sed -ne '/@sed/!s/# //p' $(MAKEFILE_LIST)
 
-test:        # Run all unit tests.
-	@docker run \
+test:         # Run all unit tests.
+	@docker run --rm \
 		-w $$PWD \
 		-v $$PWD:$$PWD \
 		--entrypoint sh \
 		sparkprime/jsonnet \
 		tests.sh
 
-test-update: # Run all unit tests while copying test_output.json to compiled.json file.
-	@docker run \
+test-update:  # Run all unit tests while copying test_output.json to compiled.json file.
+	@docker run --rm \
 		-w $$PWD \
 		-v $$PWD:$$PWD \
 		--entrypoint sh \
 		sparkprime/jsonnet \
 		tests.sh update
+
+gen-api-docs: # Generate api-docs.md from source code comments.
+	@docker run --rm \
+		-u $$UID \
+		-v $$PWD:$$PWD \
+		-w $$PWD \
+		trotttrotttrott/jsonnetdoc:4f806c6 \
+		grafonnet --markdown \
+		> docs/api-docs.md

--- a/grafonnet/alert_condition.libsonnet
+++ b/grafonnet/alert_condition.libsonnet
@@ -4,6 +4,8 @@
    * Currently the only condition type that exists is a Query condition
    * that allows to specify a query letter, time range and an aggregation function.
    *
+   * @name alertCondition.new
+   *
    * @param evaluatorParams Value of threshold
    * @param evaluatorType Type of threshold
    * @param operatorType Operator between conditions
@@ -12,6 +14,7 @@
    * @param queryTimeEnd End of time range
    * @param reducerParams Params of an aggregation function
    * @param reducerType Name of an aggregation function
+   *
    * @return A json that represents a condition of alert
    */
   new(

--- a/grafonnet/alertlist.libsonnet
+++ b/grafonnet/alertlist.libsonnet
@@ -1,4 +1,7 @@
 {
+  /**
+   * @name alertlist.new
+   */
   new(
     title='',
     span=null,

--- a/grafonnet/annotation.libsonnet
+++ b/grafonnet/annotation.libsonnet
@@ -9,6 +9,11 @@
       name: 'Annotations & Alerts',
       type: 'dashboard',
     },
+
+  /**
+   * @name annotation.datasource
+   */
+
   datasource(
     name,
     datasource,

--- a/grafonnet/cloudwatch.libsonnet
+++ b/grafonnet/cloudwatch.libsonnet
@@ -2,6 +2,8 @@
   /**
    * Return a CloudWatch Target
    *
+   * @name cloudwatch.target
+   *
    * @param region
    * @param namespace
    * @param metric

--- a/grafonnet/dashboard.libsonnet
+++ b/grafonnet/dashboard.libsonnet
@@ -1,6 +1,9 @@
 local timepickerlib = import 'timepicker.libsonnet';
 
 {
+  /**
+   * @name dashboard.new
+   */
   new(
     title,
     editable=false,

--- a/grafonnet/dashlist.libsonnet
+++ b/grafonnet/dashlist.libsonnet
@@ -3,6 +3,8 @@
    * Returns a new dashlist panel that can be added in a row.
    * It requires the dashlist panel plugin in grafana, which is built-in.
    *
+   * @name dashlist.new
+   *
    * @param title The title of the dashlist panel.
    * @param description Description of the panel
    * @param query Query to search by

--- a/grafonnet/elasticsearch.libsonnet
+++ b/grafonnet/elasticsearch.libsonnet
@@ -1,4 +1,7 @@
 {
+  /**
+   * @name elasticsearch.target
+   */
   target(
     query,
     timeField,

--- a/grafonnet/gauge.libsonnet
+++ b/grafonnet/gauge.libsonnet
@@ -1,4 +1,7 @@
 {
+  /**
+   * @name gauge.new
+   */
   new(
     title,
     datasource=null,

--- a/grafonnet/graph_panel.libsonnet
+++ b/grafonnet/graph_panel.libsonnet
@@ -3,6 +3,8 @@
    * Returns a new graph panel that can be added in a row.
    * It requires the graph panel plugin in grafana, which is built-in.
    *
+   * @name graphPanel.new
+   *
    * @param title The title of the graph panel.
    * @param span Width of the panel
    * @param datasource Datasource

--- a/grafonnet/graphite.libsonnet
+++ b/grafonnet/graphite.libsonnet
@@ -2,6 +2,8 @@
   /**
    * Return an Graphite Target
    *
+   * @name graphite.target
+   *
    * @param target Graphite Query. Nested queries are possible by adding the query reference (refId).
    * @param targetFull Expanding the @target. Used in nested queries.
    * @param hide Disable query on graph.

--- a/grafonnet/heatmap_panel.libsonnet
+++ b/grafonnet/heatmap_panel.libsonnet
@@ -1,7 +1,9 @@
 {
-  /*
+  /**
    * Returns a heatmap panel.
    * Requires the heatmap panel plugin in Grafana, which is built-in.
+   *
+   * @name heatmapPanel.new
    *
    * @param title The title of the heatmap panel
    * @param datasource Datasource

--- a/grafonnet/influxdb.libsonnet
+++ b/grafonnet/influxdb.libsonnet
@@ -2,6 +2,8 @@
   /**
    * Return an InfluxDB Target
    *
+   * @name influxdb.target
+   *
    * @param query Raw InfluxQL statement
    * @param alias Alias By pattern
    * @param datasource Datasource

--- a/grafonnet/link.libsonnet
+++ b/grafonnet/link.libsonnet
@@ -1,4 +1,7 @@
 {
+  /**
+   * @name link.dashboards
+   */
   dashboards(
     title,
     tags,

--- a/grafonnet/log_panel.libsonnet
+++ b/grafonnet/log_panel.libsonnet
@@ -3,6 +3,8 @@
    * Returns a new log panel that can be added in a row.
    * It requires the log panel plugin in grafana, which is built-in.
    *
+   * @name logPanel.new
+   *
    * @param title The title of the log panel.
    * @param span Width of the panel
    * @param datasource Datasource

--- a/grafonnet/loki.libsonnet
+++ b/grafonnet/loki.libsonnet
@@ -1,4 +1,7 @@
 {
+  /**
+   * @name loki.target
+   */
   target(
     expr,
     hide=null,

--- a/grafonnet/pie_chart_panel.libsonnet
+++ b/grafonnet/pie_chart_panel.libsonnet
@@ -3,6 +3,8 @@
    * Returns a new pie chart panel that can be added in a row.
    * It requires the pie chart panel plugin in grafana, which needs to be explicitly installed.
    *
+   * @name pieChartPanel.new
+   *
    * @param title The title of the pie chart panel.
    * @param description Description of the panel
    * @param span Width of the panel

--- a/grafonnet/pluginlist.libsonnet
+++ b/grafonnet/pluginlist.libsonnet
@@ -3,6 +3,8 @@
    * Returns a new pluginlist panel that can be added in a row.
    * It requires the pluginlist panel plugin in grafana, which is built-in.
    *
+   * @name pluginlist.new
+   *
    * @param title The title of the pluginlist panel.
    * @param description Description of the panel
    * @param limit Set maximum items in a list

--- a/grafonnet/prometheus.libsonnet
+++ b/grafonnet/prometheus.libsonnet
@@ -1,4 +1,7 @@
 {
+  /**
+   * @name prometheus.target
+   */
   target(
     expr,
     format='time_series',

--- a/grafonnet/row.libsonnet
+++ b/grafonnet/row.libsonnet
@@ -1,4 +1,7 @@
 {
+  /**
+   * @name row.new
+   */
   new(
     title='Dashboard Row',
     height=null,

--- a/grafonnet/singlestat.libsonnet
+++ b/grafonnet/singlestat.libsonnet
@@ -1,4 +1,7 @@
 {
+  /**
+   * @name singlestat.new
+   */
   new(
     title,
     format='none',

--- a/grafonnet/sql.libsonnet
+++ b/grafonnet/sql.libsonnet
@@ -1,4 +1,7 @@
 {
+  /**
+   * @name sql.target
+   */
   target(
     rawSql,
     datasource=null,

--- a/grafonnet/table_panel.libsonnet
+++ b/grafonnet/table_panel.libsonnet
@@ -3,6 +3,8 @@
    * Returns a new table panel that can be added in a row.
    * It requires the table panel plugin in grafana, which is built-in.
    *
+   * @name table.new
+   *
    * @param title The title of the graph panel.
    * @param span Width of the panel
    * @param height Height of the panel

--- a/grafonnet/template.libsonnet
+++ b/grafonnet/template.libsonnet
@@ -1,4 +1,7 @@
 {
+  /**
+   * @name template.new
+   */
   new(
     name,
     datasource,
@@ -34,6 +37,9 @@
       type: 'query',
       useTags: false,
     },
+  /**
+   * @name template.interval
+   */
   interval(
     name,
     query,
@@ -66,6 +72,9 @@
     else
       current,
   },
+  /**
+   * @name template.datasource
+   */
   datasource(
     name,
     query,
@@ -97,6 +106,9 @@
   else
     refresh,
   filterAuto(str):: str != 'auto',
+  /**
+   * @name template.custom
+   */
   custom(
     name,
     query,
@@ -131,6 +143,9 @@
       query: query,
       type: 'custom',
     },
+  /**
+   * @name template.text
+   */
   text(
     name,
     label=''

--- a/grafonnet/text.libsonnet
+++ b/grafonnet/text.libsonnet
@@ -1,4 +1,7 @@
 {
+  /**
+   * @name text.new
+   */
   new(
     title='',
     span=null,

--- a/grafonnet/timepicker.libsonnet
+++ b/grafonnet/timepicker.libsonnet
@@ -1,4 +1,7 @@
 {
+  /**
+   * @name timepicker.new
+   */
   new(
     refresh_intervals=[
       '5s',

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,3 +10,4 @@ nav:
   - Examples: 'examples.md'
   - Style Guide: 'style-guide.md'
   - Comunity Plugins: 'community-plugins.md'
+  - API Docs: 'api-docs.md'


### PR DESCRIPTION
Generates API docs from comments using https://github.com/trotttrotttrott/jsonnetdoc. It's not the most elegant documentation parser, but it seems to cover our requirements for now.

I've also added the `@name` tag to all functions so at least the proper names will be listed. I'm hoping we can add more documentation in the coming weeks so it becomes more complete.

Output preview: https://gist.github.com/trotttrotttrott/1f510d6a3e004073d36e94775523dac7.

A step has been added to the circleci build to generate the docs so it will be included in https://grafana.github.io/grafonnet-lib/.