### PR TITLE
Add pluging to the list (polystat)

### DIFF
--- a/docs/community-plugins.md
+++ b/docs/community-plugins.md
@@ -18,3 +18,4 @@ please submit a pull request to get it added to this list.
 
 * [Status panel (by Vonage)](https://grafana.com/grafana/plugins/vonage-status-panel) template plugin: [link](https://github.com/DifferentialOrange/grafonnet-status-panel).
 * [Statusmap panel (by Flant)](https://grafana.com/grafana/plugins/flant-statusmap-panel) template plugin: [link](https://github.com/blablacar/grafonnet-lib-plugins).
+* [Polystat panel (by Grafana Labs)](https://grafana.com/grafana/plugins/grafana-polystat-panel) template plugin: [link](https://github.com/thelastpickle/grafonnet-polystat-panel).


### PR DESCRIPTION
Grafonnet extention for polystat plugin.

Fixes #141 - @achilles42
Replaces - PRs #137 @ankit1ank and #210 @jbfavre

The work in #210 seems to be as good as mine (probably even better), but it is built within the grafonnet repo, which we don't want anymore. I'm happy to merge tests (that are missing in my team's repo or to have my repo forked by @jbfavre if you want to maintain it yourself.