### PR TITLE
Fix tablePanel.addTargets

### DIFF
--- a/grafonnet/table_panel.libsonnet
+++ b/grafonnet/table_panel.libsonnet
@@ -49,50 +49,13 @@
     [if description != null then 'description']: description,
     [if transform != null then 'transform']: transform,
     [if transparent == true then 'transparent']: transparent,
-
     _nextTarget:: 0,
-    addTarget(target):: self + self.addTargets([target]),
-    addTargets(newtargets)::
-      self {
-        local n = std.foldl(function(numOfTargets, p)
-          (if 'targets' in p then
-             numOfTargets + 1 + std.length(p.targets)
-           else
-             numOfTargets + 1), newtargets, 0),
-        local nextTarget = super._nextTarget,
-        local _targets = std.makeArray(
-          std.length(newtargets), function(i)
-            newtargets[i] {
-              refId: std.char(std.codepoint('A') + nextTarget + (
-                if i == 0 then
-                  0
-                else
-                  if 'targets' in _targets[i - 1] then
-                    (std.codepoint(_targets[i - 1].refId) - nextTarget) + 1 + std.length(_targets[i - 1].targets)
-                  else
-                    (std.codepoint(_targets[i - 1].refId) - nextTarget) + 1
-              )),
-              [if 'targets' in newtargets[i] then 'targets']: std.makeArray(
-                std.length(newtargets[i].targets), function(j)
-                  newtargets[i].targets[j] {
-                    refId: std.char(std.codepoint('A') + 1 + j +
-                                    nextTarget + (
-                      if i == 0 then
-                        0
-                      else
-                        if 'targets' in _targets[i - 1] then
-                          (std.codepoint(_targets[i - 1].refId) - nextTarget) + 1 + std.length(_targets[i - 1].targets)
-                        else
-                          (std.codepoint(_targets[i - 1].refId) - nextTarget) + 1
-                    )),
-                  }
-              ),
-            }
-        ),
-
-        _nextTarget: nextTarget + n,
-        targets+::: _targets,
-      },
+    addTarget(target):: self {
+      local nextTarget = super._nextTarget,
+      _nextTarget: nextTarget + 1,
+      targets+: [target { refId: std.char(std.codepoint('A') + nextTarget) }],
+    },
+    addTargets(targets):: std.foldl(function(p, t) p.addTarget(t), targets, self),
     addColumn(field, style):: self {
       local style_ = style { pattern: field },
       local column_ = { text: field, value: field },

--- a/tests/table_panel/test_compiled.json
+++ b/tests/table_panel/test_compiled.json
@@ -105,7 +105,7 @@
             },
             {
                "b": "foo",
-               "refId": "\u0083"
+               "refId": "B"
             }
          ],
          "timeFrom": null,


### PR DESCRIPTION
`.addTargets` was not setting refId correctly. All those after the first target ('A') appear to be output as unicode. This ends up blank when rendered and cannot be referenced.

tablePanel now uses the same strategy as graphPanel for setting refId on targets.