### PR TITLE
Fix doc links in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,3 +42,6 @@ jsonnet -J <path> dashboard.jsonnet
 ```
 
 As you build your own mixins/dashboards, you should add additional `-J` paths.
+
+[brew]:https://brew.sh/
+[jsonnetgh]:https://github.com/google/jsonnet


### PR DESCRIPTION
Broken since this [commit](https://github.com/grafana/grafonnet-lib/commit/93432431b76924da4b993e7457339e07e3dbcba6#diff-04c6e90faac2675aa89e2176d2eec7d8) 