### PR TITLE
Add pluginVersion and some other options to gauge panel

### DIFF
--- a/grafonnet/gauge.libsonnet
+++ b/grafonnet/gauge.libsonnet
@@ -11,6 +11,16 @@
     description='',
     height=null,
     transparent=null,
+    max=100,
+    min=0,
+    gauge_title=null,
+    unit='percent',
+    values=false,
+    labels=false,
+    markers=true,
+    orientation='auto',
+    threshold_mode='absolute',
+    pluginVersion=null,
   )::
     {
       [if description != '' then 'description']: description,
@@ -20,19 +30,50 @@
       [if span != null then 'span']: span,
       title: title,
       type: 'gauge',
+      [if pluginVersion != null then 'pluginVersion']: pluginVersion,
       datasource: datasource,
       options: {
         fieldOptions: {
           calcs: [
             calc,
           ],
+          defaults: {
+            mappings: [],
+            max: max,
+            min: min,
+            thresholds: {
+              mode: threshold_mode,
+              steps: [],
+            },
+            title: gauge_title,
+            unit: unit,
+          },
+          overrides: [],
+          values: values,
         },
+        orientation: orientation,
+        showThresholdLabels: labels,
+        showThresholdMarkers: markers,
       },
       _nextTarget:: 0,
       addTarget(target):: self {
         local nextTarget = super._nextTarget,
         _nextTarget: nextTarget + 1,
         targets+: [target { refId: std.char(std.codepoint('A') + nextTarget) }],
+      },
+      addThreshold(color, value=null):: self {
+        options+: {
+          fieldOptions+: {
+            defaults+: {
+              thresholds+: {
+                steps+: [{
+                  color: color,
+                  value: value,
+                }],
+              },
+            },
+          },
+        },
       },
     },
 

--- a/tests/gauge/test.jsonnet
+++ b/tests/gauge/test.jsonnet
@@ -18,4 +18,14 @@ local gauge = grafana.gauge;
     time_from='5m',
     transparent=true
   ),
+  threshold: gauge.new(
+    'threshold',
+    calc='mean',
+    datasource='mem',
+    labels=true,
+    markers=false,
+    max=95,
+    min=10,
+    pluginVersion='6.7.3',
+  ).addThreshold('green').addThreshold('yellow', 50).addThreshold('red', 80),
 }

--- a/tests/gauge/test_compiled.json
+++ b/tests/gauge/test_compiled.json
@@ -6,8 +6,24 @@
          "fieldOptions": {
             "calcs": [
                "sum"
-            ]
-         }
+            ],
+            "defaults": {
+               "mappings": [ ],
+               "max": 100,
+               "min": 0,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [ ]
+               },
+               "title": null,
+               "unit": "percent"
+            },
+            "overrides": [ ],
+            "values": false
+         },
+         "orientation": "auto",
+         "showThresholdLabels": false,
+         "showThresholdMarkers": true
       },
       "span": 6,
       "timeFrom": "5m",
@@ -21,8 +37,24 @@
          "fieldOptions": {
             "calcs": [
                "mean"
-            ]
-         }
+            ],
+            "defaults": {
+               "mappings": [ ],
+               "max": 100,
+               "min": 0,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [ ]
+               },
+               "title": null,
+               "unit": "percent"
+            },
+            "overrides": [ ],
+            "values": false
+         },
+         "orientation": "auto",
+         "showThresholdLabels": false,
+         "showThresholdMarkers": true
       },
       "span": 12,
       "title": "single",
@@ -34,8 +66,24 @@
          "fieldOptions": {
             "calcs": [
                "mean"
-            ]
-         }
+            ],
+            "defaults": {
+               "mappings": [ ],
+               "max": 100,
+               "min": 0,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [ ]
+               },
+               "title": null,
+               "unit": "percent"
+            },
+            "overrides": [ ],
+            "values": false
+         },
+         "orientation": "auto",
+         "showThresholdLabels": false,
+         "showThresholdMarkers": true
       },
       "span": 12,
       "targets": [
@@ -44,6 +92,48 @@
          "target3{\"refId\": \"C\"}"
       ],
       "title": "targets",
+      "type": "gauge"
+   },
+   "threshold": {
+      "datasource": "mem",
+      "options": {
+         "fieldOptions": {
+            "calcs": [
+               "mean"
+            ],
+            "defaults": {
+               "mappings": [ ],
+               "max": 95,
+               "min": 10,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": null
+                     },
+                     {
+                        "color": "yellow",
+                        "value": 50
+                     },
+                     {
+                        "color": "red",
+                        "value": 80
+                     }
+                  ]
+               },
+               "title": null,
+               "unit": "percent"
+            },
+            "overrides": [ ],
+            "values": false
+         },
+         "orientation": "auto",
+         "showThresholdLabels": true,
+         "showThresholdMarkers": false
+      },
+      "pluginVersion": "6.7.3",
+      "title": "threshold",
       "type": "gauge"
    }
 }


### PR DESCRIPTION
Add pluginVersion option to gauge panel template.
Add some additional options (based on ver. 6.7.3): threshold options, gauge title, gauge unit, value display, gauge orientation.