### PR TITLE
Documentation Cleanup and Addition of "Usage" Page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,4 +23,9 @@ git clone https://github.com/grafana/grafonnet-lib.git
 A slightly more advanced approach is to use
 [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler).
 
+```
+jb init
+jb install https://github.com/grafana/grafonnet-lib/grafonnet
+```
+
 See the [Usage](usage) page for next steps.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,46 +2,25 @@
 
 ## Prerequisites
 
-Grafonnet requires Jsonnet.
+You must first install Jsonnet.
 
-### Linux
+See the instructions on its GitHub page:
 
-You must build the binary. For details, [see the GitHub
-repository][jsonnetgh].
+[https://github.com/google/jsonnet#packages](https://github.com/google/jsonnet#packages)
 
-### Mac OS X
+There is also an implementation in Go if you'd prefer:
 
-Jsonnet is available in Homebrew. If you do not have Homebrew installed,
-[install it][brew].
-
-Then run:
-
-```
-brew install jsonnet
-```
+[https://github.com/google/go-jsonnet#installation-instructions](https://github.com/google/go-jsonnet#installation-instructions)
 
 ## Install Grafonnet
 
-Clone this git repository:
+Simplest way to install Grafonnet is to clone the repository:
 
 ```
 git clone https://github.com/grafana/grafonnet-lib.git
 ```
 
-Then import the grafonnet in your jsonnet code:
+A slightly more advanced approach is to use
+[jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler).
 
-```
-local grafana = import 'grafonnet/grafana.libsonnet';
-```
-
-To be able to find the grafonnet library, you must pass the root of the git
-repository to grafonnet using the `-J` option:
-
-```
-jsonnet -J <path> dashboard.jsonnet
-```
-
-As you build your own mixins/dashboards, you should add additional `-J` paths.
-
-[brew]:https://brew.sh/
-[jsonnetgh]:https://github.com/google/jsonnet
+See the [Usage](usage) page for next steps.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,15 @@
 # ![Grafonnet logo](images/grafonnet.png)
 
 Grafonnet provides an easy and maintainable way of writing
-[grafana](https://grafana.org) dashboards. Instead of generating JSON files and
+[Grafana](https://grafana.org) dashboards. Instead of generating JSON files and
 maintaining them, you can easily create your own dashboards using the many
 helpers grafonnet-lib offers you, thanks to the data templating language
-[jsonnet](http://jsonnet.org/).
+[Jsonnet](http://jsonnet.org/).
 
 ## Grafana dashboard
 
-[Grafana](https://grafana.org) is using JSON as format for the dashboards. While
+[A dashboard in Grafana is represented by a JSON
+object](https://grafana.com/docs/grafana/latest/reference/dashboard/). While
 this choice makes sense from a technical point of view, people who want to keep
 those dashboards under version control end up putting large, independent JSON
 files under source control.
@@ -17,8 +18,8 @@ When doing so, it is hard to maintain the same links, templates, or even
 annotation between graphs. It usually requires a lot of custom tooling to
 change and keep those Json files aligned. There are alternatives, like
 [grafanalib](https://github.com/weaveworks/grafanalib), that makes thing easier.
-However, as Grafonnet is using [jsonnet](http://jsonnet.org/), a superset of
-Json, it gives you out of the box a very easy way to use any feature of grafana
+However, as Grafonnet is using [Jsonnet](http://jsonnet.org/), a superset of
+JSON, it gives you out of the box a very easy way to use any feature of grafana
 that would not be covered by Grafonnet already.
 
 ## Scope

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -117,3 +117,53 @@ by running a Grafana container on your local Docker engine:
 ```
 docker run --rm -p 3000:3000 grafana/grafana
 ```
+
+## Grizzly
+
+Another way you could manage your Grafonnet code is by using
+[Grizzly](https://github.com/malcolmholmes/grizzly). Grizzly is a command line
+tool for managing Grafana dashboards as code written in Jsonnet.
+
+In this section, we'll assume you've used
+[jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler) to install
+Grafonnet. In which case your current directory would look like this:
+
+```
+▸ tree -L 2 .
+.
+├── dashboards.jsonnet
+├── jsonnetfile.json
+├── jsonnetfile.lock.json
+└── vendor
+    ├── github.com
+    └── grafonnet -> github.com/grafana/grafonnet-lib/grafonnet
+
+3 directories, 3 files
+```
+
+`dashboards.jsonnet` (now plural) will look slightly different than before:
+
+```
+local grafana = import 'grafonnet/grafana.libsonnet';
+
+{
+  grafanaDashboards:: {
+    empty_dashboard: grafana.dashboard.new('Empty Dashboard'),
+  },
+}
+```
+
+First you need to set the `GRAFANA_URL` environment variable:
+
+```
+export GRAFANA_URL=http://admin:admin@localhost:3000
+```
+
+Next create the dashboard with on your Grafana instance with:
+
+```
+grr apply dashboards.jsonnet
+```
+
+Check [Grizzly's GitHub page](https://github.com/malcolmholmes/grizzly) for
+other commands and documentation.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -115,7 +115,7 @@ The above URL assumes you're running a Grafana instance locally. You can do that
 by running a Grafana container on your local Docker engine:
 
 ```
-docker run --rm -p 3000:3000 grafana/grafana
+docker run --rm -d -p 3000:3000 grafana/grafana
 ```
 
 ## Grizzly

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,119 @@
+# Usage
+
+## The Simplest Approach
+
+Your current directory would look something like this:
+
+```
+▸ tree -L 1 .
+.
+├── dashboard.jsonnet
+└── grafonnet-lib
+
+1 directory, 1 file
+```
+
+You've cloned Grafonnet and you've create a file called, `dashboard.jsonnet`.
+That file might look something like this:
+
+```
+local grafana = import 'grafonnet/grafana.libsonnet';
+
+grafana.dashboard.new('Empty Dashboard')
+```
+
+From here, you can run the following command to generate your dashboard:
+
+```
+jsonnet -J grafonnet-lib dashboard.jsonnet
+```
+
+<details>
+<summary>show output</summary>
+
+```
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [ ]
+   },
+   "editable": false,
+   "gnetId": null,
+   "graphTooltip": 0,
+   "hideControls": false,
+   "id": null,
+   "links": [ ],
+   "refresh": "",
+   "rows": [ ],
+   "schemaVersion": 14,
+   "style": "dark",
+   "tags": [ ],
+   "templating": {
+      "list": [ ]
+   },
+   "time": {
+      "from": "now-6h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "browser",
+   "title": "Empty Dashboard",
+   "version": 0
+}
+
+```
+
+</details>
+
+Next you need to actually create the dashboard on Grafana. One option is to
+paste the dashboard JSON on the Grafana UI.
+
+A less tedious approach would be to use Grafana's [dashboard
+API](https://grafana.com/docs/grafana/latest/http_api/dashboard/). For example,
+you could create and execute this script in our example directory:
+
+```
+#!/usr/bin/env bash
+
+JSONNET_PATH=grafonnet-lib \
+  jsonnet dashboard.jsonnet > dashboard.json
+
+payload="{\"dashboard\": $(jq . dashboard.json), \"overwrite\": true}"
+
+curl -X POST $BASIC_AUTH \
+  -H 'Content-Type: application/json' \
+  -d "${payload}" \
+  "http://admin:admin@localhost:3000/api/dashboards/db"
+```
+
+The above URL assumes you're running a Grafana instance locally. You can do that
+by running a Grafana container on your local Docker engine:
+
+```
+docker run --rm -p 3000:3000 grafana/grafana
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ theme:
 nav:
   - Home: 'index.md'
   - Getting Started: 'getting-started.md'
+  - Usage: 'usage.md'
   - Examples: 'examples.md'
   - Style Guide: 'style-guide.md'
   - Community Plugins: 'community-plugins.md'


### PR DESCRIPTION
### Cleanup

docs/index just has minor copy and link updates.

docs/getting-started:
* No installation examples. Defers to Jsonnet's GH page.
* Mentions go-jsonnet as option.
* Grafonnet installation mentions jsonnet-bundler.
* Removes basic usage example. Links to the "Usage" page in this PR

### docs/usage

Includes two examples:

"The Simplest Approach" - walkthrough using `jsonnet` command and a script for creating the dashboard with the HTTP API.

"Grizzly" - walkthrough using [Grizzly](https://github.com/malcolmholmes/grizzly).

Rendered preview here: https://gist.github.com/trotttrotttrott/c6d08dc64e4be60b3c001aa6cae5c412.