### PR TITLE
Upgrade jsonnet to 0.16.0 and use jsonnetfmt command for test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:         # Run all unit tests.
 		-w $$PWD \
 		-v $$PWD:$$PWD \
 		--entrypoint sh \
-		sparkprime/jsonnet \
+		bitnami/jsonnet:0.16.0 \
 		tests.sh
 
 test-update:  # Run all unit tests while copying test_output.json to compiled.json file.
@@ -15,7 +15,7 @@ test-update:  # Run all unit tests while copying test_output.json to compiled.js
 		-w $$PWD \
 		-v $$PWD:$$PWD \
 		--entrypoint sh \
-		sparkprime/jsonnet \
+		bitnami/jsonnet:0.16.0 \
 		tests.sh update
 
 gen-api-docs: # Generate api-docs.md from source code comments.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test:         # Run all unit tests.
 	@docker run --rm \
 		-w $$PWD \
 		-v $$PWD:$$PWD \
-		--entrypoint sh \
+		--entrypoint bash \
 		bitnami/jsonnet:0.16.0 \
 		tests.sh
 
@@ -14,7 +14,7 @@ test-update:  # Run all unit tests while copying test_output.json to compiled.js
 	@docker run --rm \
 		-w $$PWD \
 		-v $$PWD:$$PWD \
-		--entrypoint sh \
+		--entrypoint bash \
 		bitnami/jsonnet:0.16.0 \
 		tests.sh update
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+UID = $(shell id -u $(USER))
+GID = $(shell id -g $(USER))
+
 help:         # Show this message.
 	@echo "\nAvailable Targets:\n"
 	@sed -ne '/@sed/!s/# //p' $(MAKEFILE_LIST)
@@ -6,6 +9,7 @@ test:         # Run all unit tests.
 	@docker run --rm \
 		-w $$PWD \
 		-v $$PWD:$$PWD \
+		-u $(UID):$(GID) \
 		--entrypoint bash \
 		bitnami/jsonnet:0.16.0 \
 		tests.sh
@@ -14,6 +18,7 @@ test-update:  # Run all unit tests while copying test_output.json to compiled.js
 	@docker run --rm \
 		-w $$PWD \
 		-v $$PWD:$$PWD \
+		-u $(UID):$(GID) \
 		--entrypoint bash \
 		bitnami/jsonnet:0.16.0 \
 		tests.sh update

--- a/tests.sh
+++ b/tests.sh
@@ -7,9 +7,9 @@ for i in `find . -name '*.jsonnet' -or -name '*.libsonnet'`
 do
     t="Formatting $i..."
     if [[ "$1" == "update" ]]; then
-        jsonnet fmt -i $jsonnet_fmt $i
+        jsonnetfmt -i $jsonnet_fmt $i
     fi
-    if jsonnet fmt --test $jsonnet_fmt $i;
+    if jsonnetfmt --test $jsonnet_fmt $i;
     then
         echo $t OK
     else


### PR DESCRIPTION
`jsonent fmt` is not available in jsonnet 0.13.0 and upper.
https://github.com/google/jsonnet/releases/tag/v0.13.0

This PR changes the docker image for testing to use the latest version of jsonnet.