### PR TITLE
Contributing Guide Updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,46 @@ Grafana](https://github.com/grafana/grafana/blob/master/CODE_OF_CONDUCT.md). To
 help us create a safe and positive community experience for all, we require all
 participants to adhere to it.
 
-## Plugin Scope
+## Version Support
+
+We strive to only support the latest and last major Grafana versions - currently
+6 and 7.
+
+## Feature Support
 
 **Grafonnet only aims to support core features and plugins.**
+
+In terms of plugins, this means only those that are pre-installed:
+
+* Alert List
+* Azure Monitor
+* Bar gauge
+* CloudWatch
+* Dashboard list
+* Elasticsearch
+* Gauge
+* Graph
+* Graphite
+* Heatmap
+* InfluxDB
+* Jaeger
+* Logs
+* Loki
+* Microsoft SQL Server
+* MySQL
+* News
+* OpenTSDB
+* Plugin list
+* PostgreSQL
+* Prometheus
+* Singlestat
+* Stackdriver
+* Stat
+* Table
+* Table (old)
+* TestData DB
+* Text
+* Zipkin
 
 While Grafonnet itself only supports core Grafana functionality, we strongly
 encourage development and use of community Grafonnet extensions. See the


### PR DESCRIPTION
Changes that reflect recent discussions on what we believe Grafonnet should support.

* Specify support for only latest and last major Grafana versions.
* List pre-installed Grafana plugins to indicate more clearly which are intended to be supported.
* Rename "Plugin Support" section to "Feature Support".

The intent of these changes is to keep the codebase focused. This is expected to facilitate improvement of code quality and keeping up with Grafana updates/innovations.