### PR TITLE
Added JSDoc for template.new() and interval()

### DIFF
--- a/grafonnet/template.libsonnet
+++ b/grafonnet/template.libsonnet
@@ -60,7 +60,7 @@
    * Use an [interval variable](https://grafana.com/docs/grafana/latest/variables/variable-types/add-interval-variable/) to represent time spans such as '1m', '1h', '1d'. You can think of them as a dashboard-wide "group by time" command. Interval variables change how the data is grouped in the visualization. You can also use the Auto Option to return a set number of data points per time span.
    * You can use an interval variable as a parameter to group by time (for InfluxDB), date histogram interval (for Elasticsearch), or as a summarize function parameter (for Graphite).
    *
-   * @name template.interval Returns a new interval variable for templating.
+   * @name template.interval
    *
    * @param name Variable name
    * @param query

--- a/grafonnet/template.libsonnet
+++ b/grafonnet/template.libsonnet
@@ -1,6 +1,25 @@
 {
   /**
-   * @name template.new
+   * Returns a new template that can be added to a dashboard.
+   * See what's a [template](https://grafana.com/docs/grafana/latest/variables/templates-and-variables/#templates)
+   * 
+   * @name template.new Instanciate a new template.
+   * 
+   * @param name Name of variable
+   * @param datasource Template [datasource](https://grafana.com/docs/grafana/latest/variables/variable-types/add-data-source-variable/)
+   * @param query [Query expression](https://grafana.com/docs/grafana/latest/variables/variable-types/add-query-variable/) for the datasource.
+   * @param label (optional) Display name of the variable dropdown. If null, then the dropdown label will be the variable name.
+   * @param allValues (optional) Formatting for [multi-value variables](https://grafana.com/docs/grafana/latest/variables/formatting-multi-value-variables/#formatting-multi-value-variables)
+   * @param tagValuesQuery (optional, experimental feature) Group values into [selectable tags](https://grafana.com/docs/grafana/latest/variables/variable-value-tags/)
+   * @param current
+   * @param hide Choose a hide option: '' (default) the variable dropdown displays the variable Name or Label value. 'label' the variable dropdown only displays the selected variable value and a down arrow. Any other value, no variable dropdown is displayed on the dashboard.
+   * @param regex (optional) Regex expression to filter or capture specific parts of the names returned by your data source query. To see examples, refer to [Filter variables with regex](https://grafana.com/docs/grafana/latest/variables/filter-variables-with-regex/).
+   * @param refresh 'never' (default): Variables queries are cached and values are not updated. This is fine if the values never change, but problematic if they are dynamic and change a lot. 'load': Queries the data source every time the dashboard loads. This slows down dashboard loading, because the variable query needs to be completed before dashboard can be initialized. 'time': Queries the data source when the dashboard time range changes. Only use this option if your variable options query contains a time range filter or is dependent on the dashboard time range.
+   * @param includeAll Whether all value option is available or not. False by default.
+   * @param multi Whether multiple values can be selected or not from variable value list. False by default.
+   * @param sort 0 (default): Without Sort, 1: Alphabetical (asc), 2: Alphabetical (desc), 3: Numerical (asc), 4: Numerical (desc).
+   *
+   * @return A [template](https://grafana.com/docs/grafana/latest/variables/templates-and-variables/#templates)
    */
   new(
     name,

--- a/grafonnet/template.libsonnet
+++ b/grafonnet/template.libsonnet
@@ -3,7 +3,7 @@
    * Returns a new template that can be added to a dashboard.
    * See what's a [template](https://grafana.com/docs/grafana/latest/variables/templates-and-variables/#templates).
    *
-   * @name template.new Returns a new template.
+   * @name template.new
    *
    * @param name Name of variable
    * @param datasource Template [datasource](https://grafana.com/docs/grafana/latest/variables/variable-types/add-data-source-variable/)

--- a/grafonnet/template.libsonnet
+++ b/grafonnet/template.libsonnet
@@ -1,9 +1,9 @@
 {
   /**
    * Returns a new template that can be added to a dashboard.
-   * See what's a [template](https://grafana.com/docs/grafana/latest/variables/templates-and-variables/#templates)
+   * See what's a [template](https://grafana.com/docs/grafana/latest/variables/templates-and-variables/#templates).
    * 
-   * @name template.new Instanciate a new template.
+   * @name template.new Returns a new template.
    * 
    * @param name Name of variable
    * @param datasource Template [datasource](https://grafana.com/docs/grafana/latest/variables/variable-types/add-data-source-variable/)
@@ -12,7 +12,7 @@
    * @param allValues (optional) Formatting for [multi-value variables](https://grafana.com/docs/grafana/latest/variables/formatting-multi-value-variables/#formatting-multi-value-variables)
    * @param tagValuesQuery (optional, experimental feature) Group values into [selectable tags](https://grafana.com/docs/grafana/latest/variables/variable-value-tags/)
    * @param current
-   * @param hide Choose a hide option: '' (default) the variable dropdown displays the variable Name or Label value. 'label' the variable dropdown only displays the selected variable value and a down arrow. Any other value, no variable dropdown is displayed on the dashboard.
+   * @param hide '' (default) the variable dropdown displays the variable Name or Label value. 'label' the variable dropdown only displays the selected variable value and a down arrow. Any other value, no variable dropdown is displayed on the dashboard.
    * @param regex (optional) Regex expression to filter or capture specific parts of the names returned by your data source query. To see examples, refer to [Filter variables with regex](https://grafana.com/docs/grafana/latest/variables/filter-variables-with-regex/).
    * @param refresh 'never' (default): Variables queries are cached and values are not updated. This is fine if the values never change, but problematic if they are dynamic and change a lot. 'load': Queries the data source every time the dashboard loads. This slows down dashboard loading, because the variable query needs to be completed before dashboard can be initialized. 'time': Queries the data source when the dashboard time range changes. Only use this option if your variable options query contains a time range filter or is dependent on the dashboard time range.
    * @param includeAll Whether all value option is available or not. False by default.
@@ -57,7 +57,20 @@
       useTags: false,
     },
   /**
-   * @name template.interval
+   * Use an [interval variable](https://grafana.com/docs/grafana/latest/variables/variable-types/add-interval-variable/) to represent time spans such as '1m', '1h', '1d'. You can think of them as a dashboard-wide "group by time" command. Interval variables change how the data is grouped in the visualization. You can also use the Auto Option to return a set number of data points per time span.
+   * You can use an interval variable as a parameter to group by time (for InfluxDB), date histogram interval (for Elasticsearch), or as a summarize function parameter (for Graphite).
+   * 
+   * @name template.interval Returns a new interval variable for templating.
+   *
+   * @param name Variable name
+   * @param query
+   * @param current
+   * @param hide '' (default) the variable dropdown displays the variable Name or Label value. 'label' the variable dropdown only displays the selected variable value and a down arrow. Any other value, no variable dropdown is displayed on the dashboard.
+   * @param label (optional) Display name of the variable dropdown. If null, then the dropdown label will be the variable name.
+   * @param auto_count (default: 300) Valid only if 'auto' is defined in query. Number of times the current time range will be divided to calculate the value, similar to the Max data points query option. For example, if the current visible time range is 30 minutes, then the auto interval groups the data into 30 one-minute increments. The default value is 30 steps.
+   * @param auto_min (default: '10s') Valid only if 'auto' is defined in query. The minimum threshold below which the step count intervals will not divide the time. To continue the 30 minute example, if the minimum interval is set to 2m, then Grafana would group the data into 15 two-minute increments.
+   *
+   * @return A new interval variable for templating.
    */
   interval(
     name,

--- a/grafonnet/template.libsonnet
+++ b/grafonnet/template.libsonnet
@@ -2,9 +2,9 @@
   /**
    * Returns a new template that can be added to a dashboard.
    * See what's a [template](https://grafana.com/docs/grafana/latest/variables/templates-and-variables/#templates).
-   * 
+   *
    * @name template.new Returns a new template.
-   * 
+   *
    * @param name Name of variable
    * @param datasource Template [datasource](https://grafana.com/docs/grafana/latest/variables/variable-types/add-data-source-variable/)
    * @param query [Query expression](https://grafana.com/docs/grafana/latest/variables/variable-types/add-query-variable/) for the datasource.
@@ -59,7 +59,7 @@
   /**
    * Use an [interval variable](https://grafana.com/docs/grafana/latest/variables/variable-types/add-interval-variable/) to represent time spans such as '1m', '1h', '1d'. You can think of them as a dashboard-wide "group by time" command. Interval variables change how the data is grouped in the visualization. You can also use the Auto Option to return a set number of data points per time span.
    * You can use an interval variable as a parameter to group by time (for InfluxDB), date histogram interval (for Elasticsearch), or as a summarize function parameter (for Graphite).
-   * 
+   *
    * @name template.interval Returns a new interval variable for templating.
    *
    * @param name Variable name


### PR DESCRIPTION
I found the lack of [API documentation](https://grafana.github.io/grafonnet-lib/api-docs/) to be a major obstacle to get into using Grafonnet and sharing it with teammates. I currently have to browse through the source code to understand the type and purpose of each parameter.

I offer here to add documentation to `template` and `interval`. If this PR is accepted, I will gladly send following PRs with further documentation.

Please understand that I am unfamiliar with Grafana JSON models, Jsonnet, JSDoc and its [parser implementation](https://github.com/trotttrotttrott/jsonnetdoc). I may have made mistakes I'd be more than happy to correct. I browsed source code and documentation to document grafonnet-lib to the best of my understanding. I have left some fields un-documented (`query` and `current` for example), in fear I misunderstood them.

Risks:
- Is markdown properly parsed by the JSDoc parser for jsonnet? I added links in markdown format.
- I made very long lines, not sure I could make line returns. Should I add line returns in the documentation for better readability?