### PR TITLE
Add support for bigquery target

### DIFF
--- a/grafonnet/bigquery.libsonnet
+++ b/grafonnet/bigquery.libsonnet
@@ -1,0 +1,38 @@
+{
+  /**
+   * Return a bigquery target.
+   * Requires doitintl-bigquery-datasource to be explicitly installed on grafana.
+   *
+   * @name bigquery.target
+   *
+   * @param datasource which datasource to use for querying
+   * @param rawQuery Enable/disable raw query mode
+   * @param rawSql Raw bigquery query
+   * @param convertToUTC enable/disable convert to UTC flag using true/false
+   * @param location where to process bigquery data, example: US
+   * @param orderByCol order by time or metric
+   * @param orderBySort sort by ASC or DSC
+   * @param format format result as time_series or table
+   */
+  target(
+    datasource=null,
+    rawQuery=true,
+    rawSql=null,
+    convertToUTC=false,
+    location=null,
+    orderByCol='time',
+    orderBySort='ASC',
+    format='time_series',
+    hide=null,
+  ):: {
+    [if datasource != null then 'datasource']: datasource,
+    rawQuery: rawQuery,
+    [if rawSql != null then 'rawSql']: rawSql,
+    orderByCol: if orderByCol == 'time' then '1' else if orderByCol == 'metric' then '2' else orderByCol,
+    orderBySort: if orderBySort == 'ASC' then '1' else if orderBySort == 'DSC' then '2' else orderBySort,
+    convertToUTC: convertToUTC,
+    [if location != null then 'location']: location,
+    format: format,
+    [if hide != null then 'hide']: hide,
+  },
+}

--- a/grafonnet/grafana.libsonnet
+++ b/grafonnet/grafana.libsonnet
@@ -27,4 +27,5 @@
   gaugePanel:: import 'gauge_panel.libsonnet',
   barGaugePanel:: import 'bar_gauge_panel.libsonnet',
   statPanel:: import 'stat_panel.libsonnet',
+  bigquery:: import 'bigquery.libsonnet',
 }

--- a/tests/bigquery/test.jsonnet
+++ b/tests/bigquery/test.jsonnet
@@ -1,0 +1,15 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+local bigquery = grafana.bigquery;
+
+{
+  basic: bigquery.target(
+    rawSql="SELECT $__timeGroup(date_time_col, '1h'), sum(value) as value FROM yourtable GROUP BY time ORDER BY time",
+  ),
+  advanced: bigquery.target(
+    rawSql="SELECT $__timeGroup(date_time_col, '1h'), sum(value) as value FROM yourtable GROUP BY time ORDER BY time",
+    convertToUTC=true,
+    orderByCol='metric',
+    orderBySort='DSC',
+    location='US',
+  ),
+}

--- a/tests/bigquery/test_compiled.json
+++ b/tests/bigquery/test_compiled.json
@@ -1,0 +1,19 @@
+{
+   "advanced": {
+      "convertToUTC": true,
+      "format": "time_series",
+      "location": "US",
+      "orderByCol": "2",
+      "orderBySort": "2",
+      "rawQuery": true,
+      "rawSql": "SELECT $__timeGroup(date_time_col, '1h'), sum(value) as value FROM yourtable GROUP BY time ORDER BY time"
+   },
+   "basic": {
+      "convertToUTC": false,
+      "format": "time_series",
+      "orderByCol": "1",
+      "orderBySort": "1",
+      "rawQuery": true,
+      "rawSql": "SELECT $__timeGroup(date_time_col, '1h'), sum(value) as value FROM yourtable GROUP BY time ORDER BY time"
+   }
+}


### PR DESCRIPTION
Add support for bigquery targets. Requires [doitintl-bigquery-datasource](https://grafana.com/grafana/plugins/doitintl-bigquery-datasource/installation) to be installed on grafana