### PR TITLE
Add "selected" field to custom template variable when multi=false

### DIFF
--- a/grafonnet/template.libsonnet
+++ b/grafonnet/template.libsonnet
@@ -157,9 +157,9 @@
    *
    * @name template.custom
    * This might be numbers, strings, or even other variables.
-   * @param name Variable name
+   * @param name Variable name.
    * @param query Comma separated without spacing list of selectable values.
-   * @param current Selected value
+   * @param current Selected value. If not specified, first value is selected.
    * @param refresh (default `'never'`) `'never'`: Variables queries are cached and values are not updated. This is fine if the values never change, but problematic if they are dynamic and change a lot. `'load'`: Queries the data source every time the dashboard loads. This slows down dashboard loading, because the variable query needs to be completed before dashboard can be initialized. `'time'`: Queries the data source when the dashboard time range changes. Only use this option if your variable options query contains a time range filter or is dependent on the dashboard time range.
    * @param label (default `''`) Display name of the variable dropdown. If you don’t enter a display name, then the dropdown label will be the variable name.
    * @param valuelabels (default `{}`) Display names for values defined in query. For example, if `query='new,old'`, then you may display them as follows `valuelabels={new: 'nouveau', old: 'ancien'}`.
@@ -173,7 +173,7 @@
   custom(
     name,
     query,
-    current,
+    current=null,
     refresh='never',
     label='',
     valuelabels={},
@@ -186,6 +186,7 @@
       // self has dynamic scope, so self may not be myself below.
       // '$' can't be used neither as this object is not top-level object.
       local custom = self,
+      local query_array = std.split(query, ','),
 
       allValue: allValues,
       current: {
@@ -200,7 +201,7 @@
           custom.valuelabel(current),
         [if multi then 'selected']: true,
       },
-      options: std.map(self.option, self.query_array(query)),
+      options: std.map(self.option, if includeAll then ['All'] + query_array else query_array),
       hide: $.hide(hide),
       includeAll: includeAll,
       label: label,
@@ -217,16 +218,13 @@
       option(option):: {
         text: custom.valuelabel(option),
         value: if includeAll && option == 'All' then '$__all' else option,
-        [if multi then 'selected']: if multi && std.isArray(current) then
+        selected: if multi && std.isArray(current) then
           std.member(current, option)
-        else if multi then
-          current == option
+        else if current == null then
+          option == query_array[0]
         else
-          null,
+          option == current,
       },
-      query_array(query):: std.split(
-        if includeAll then 'All,' + query else query, ','
-      ),
     },
   /**
    * [Text box variables](https://grafana.com/docs/grafana/latest/variables/variable-types/add-text-box-variable/)

--- a/tests/template/custom_compiled.json
+++ b/tests/template/custom_compiled.json
@@ -12,10 +12,12 @@
       "name": "foo",
       "options": [
          {
+            "selected": true,
             "text": "nouveau",
             "value": "new"
          },
          {
+            "selected": false,
             "text": "ancien",
             "value": "old"
          }
@@ -37,10 +39,12 @@
       "name": "host",
       "options": [
          {
+            "selected": false,
             "text": "foo",
             "value": "foo"
          },
          {
+            "selected": true,
             "text": "bar",
             "value": "bar"
          }


### PR DESCRIPTION
Adds "selected" field to custom template variable when multi=false. Select first value as current if current is not specified.

Change was introduced in https://github.com/grafana/grafonnet-lib/pull/222 merge request, reworked due to #232 merge request contribution.

In current version of grafonnet-lib "selected" field added to custom template variable only when `multi` is *true*. But Grafana behavior is different.

If we create simple custom variable 
![image](https://user-images.githubusercontent.com/20455996/91299404-3782d880-e7aa-11ea-889b-445f10918b06.png)
Grafana's dashboard code will contain the following object:
```
{
    "allValue": null,
    "current": {
      "selected": false,
      "text": "1",
      "value": "1"
    },
    "hide": 0,
    "includeAll": false,
    "label": null,
    "multi": false,
    "name": "custom",
    "options": [
         {
            "selected": true,
            "text": "1",
            "value": "1"
         },
         {
            "selected": false,
            "text": "10",
            "value": "10"
         }
     ],
    "query": "1, 10",
    "skipUrlSync": false,
    "type": "custom"
}
```
i.e. Grafana adds "selected" field even if "multi" is *false* and, moreover, selects first value as current if user don't set current value. The behavior is the same if "Include All option" is enabled.