### PR TITLE
Fix some typos/mispellings

### DIFF
--- a/grafonnet/heatmap_panel.libsonnet
+++ b/grafonnet/heatmap_panel.libsonnet
@@ -36,7 +36,7 @@
    * @param yAxis_logBase Only if dataFormat is 'timeseries'
    * @param yAxis_min Only if dataFormat is 'timeseries', min of the Y axis
    * @param yAxis_max Only if dataFormat is 'timeseries', max of the Y axis
-   * @param yAxis_show Wheter or not to show the Y axis
+   * @param yAxis_show Whether or not to show the Y axis
    * @param yAxis_splitFactor TODO: document
    * @param yBucketBound Which bound ('lower' or 'upper') of the bucket to use, default 'auto'
    * @param yBucketNumber Number of buckets for the Y axis

--- a/grafonnet/stat_panel.libsonnet
+++ b/grafonnet/stat_panel.libsonnet
@@ -30,9 +30,9 @@
    *
    * @method addTarget(target) Adds a target object.
    * @method addTargets(targets) Adds an array of targets.
-   * @method addLink(link) Adds a link. Aregument format: `{ title: 'Link Title', url: 'https://...', targetBlank: true }`.
+   * @method addLink(link) Adds a link. Argument format: `{ title: 'Link Title', url: 'https://...', targetBlank: true }`.
    * @method addLinks(links) Adds an array of links.
-   * @method addThreshold(step) Adds a threshold step. Aregument format: `{ color: 'green', value: 0 }`.
+   * @method addThreshold(step) Adds a threshold step. Argument format: `{ color: 'green', value: 0 }`.
    * @method addThresholds(steps) Adds an array of threshold steps.
    * @method addMapping(mapping) Adds a value mapping.
    * @method addMappings(mappings) Adds an array of value mappings.


### PR DESCRIPTION
Encountered while tryng to update to latest grafonnet in kubernetes/test-infra (https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/test-infra/19004/pull-test-infra-bazel/1298709006935658496)

We have tests that prevent us from merging common mispellings / typos to cut down on the amount of trivial PRs we get.  And, it appears, causes us to make those PRs against other repos that we vendor :D

ref: https://github.com/kubernetes/test-infra/pull/19004