### PR TITLE
Add field title for stat 6.6.0

### DIFF
--- a/grafonnet/stat_panel.libsonnet
+++ b/grafonnet/stat_panel.libsonnet
@@ -17,6 +17,7 @@
    * @param graphMode (default `'area'`) 'none' or 'area' to enable sparkline mode.
    * @param justifyMode (default `'auto'`) 'auto' or 'center'.
    * @param unit (default `'none'`) Panel unit field option.
+   * @param fieldTitle (optional) Field title. May contain template variables (e.g. ${__series.name}).
    * @param min (optional) Leave empty to calculate based on all values.
    * @param max (optional) Leave empty to calculate based on all values.
    * @param decimals (optional) Number of decimal places to show.
@@ -54,6 +55,7 @@
     graphMode='area',
     justifyMode='auto',
     unit='none',
+    fieldTitle=null,
     min=null,
     max=null,
     decimals=null,
@@ -178,6 +180,7 @@
             [if decimals != null then 'decimals']: decimals,
             [if displayName != null then 'displayName']: displayName,
             [if noValue != null then 'noValue']: noValue,
+            [if fieldTitle != null then 'title']: fieldTitle,
             thresholds: {
               mode: thresholdsMode,
               steps: [],

--- a/tests/stat_panel/test.jsonnet
+++ b/tests/stat_panel/test.jsonnet
@@ -68,4 +68,10 @@ local stat = grafana.statPanel;
       { color: 'green', value: 75 },
       { color: 'red', value: 90 },
     ]),
+  field_title_grafana6:
+    stat.new(
+      '',
+      pluginVersion='6.6.0',
+      fieldTitle='My values:',
+    ),
 }

--- a/tests/stat_panel/test_compiled.json
+++ b/tests/stat_panel/test_compiled.json
@@ -130,6 +130,38 @@
       "transparent": false,
       "type": "stat"
    },
+   "field_title_grafana6": {
+      "datasource": null,
+      "links": [ ],
+      "options": {
+         "colorMode": "value",
+         "fieldOptions": {
+            "calcs": [
+               "mean"
+            ],
+            "defaults": {
+               "links": [ ],
+               "mappings": [ ],
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [ ]
+               },
+               "title": "My values:",
+               "unit": "none"
+            },
+            "fields": "",
+            "values": false
+         },
+         "graphMode": "area",
+         "justifyMode": "auto",
+         "orientation": "auto"
+      },
+      "pluginVersion": "6.6.0",
+      "targets": [ ],
+      "title": "",
+      "transparent": false,
+      "type": "stat"
+   },
    "links": {
       "datasource": null,
       "fieldConfig": {


### PR DESCRIPTION
fieldOptions.defaults.title is a parameter similar to displayName in 7.x.x.

![image](https://user-images.githubusercontent.com/20455996/91581092-aef56b00-e956-11ea-95fd-9f5f00fd2dc5.png)
