### PR TITLE
Add some missing API documentations

### DIFF
--- a/grafonnet/alertlist.libsonnet
+++ b/grafonnet/alertlist.libsonnet
@@ -1,6 +1,19 @@
 {
   /**
+   * Creates an [Alert list panel](https://grafana.com/docs/grafana/latest/panels/visualizations/alert-list-panel/)
+   *
    * @name alertlist.new
+   *
+   * @param title (default `''`)
+   * @param span (optional)
+   * @param show (default `'current'`) Whether the panel should display the current alert state or recent alert state changes.
+   * @param limit (default `10`) Sets the maximum number of alerts to list.
+   * @param sortOrder (default `'1'`) '1': alerting, '2': no_data, '3': pending, '4': ok, '5': paused
+   * @param stateFilter (optional)
+   * @param onlyAlertsOnDashboard (optional) Shows alerts only from the dashboard the alert list is in
+   * @param transparent (optional) Whether to display the panel without a background
+   * @param description (optional)
+   * @param datasource (optional)
    */
   new(
     title='',

--- a/grafonnet/bar_gauge_panel.libsonnet
+++ b/grafonnet/bar_gauge_panel.libsonnet
@@ -5,10 +5,10 @@
    * @name barGaugePanel.new
    *
    * @param title Panel title.
-   * @param description Panel description.
-   * @param datasource Panel datasource.
-   * @param unit The unit of the data.
-   * @param thresholds An array of threashold values.
+   * @param description (optional) Panel description.
+   * @param datasource (optional) Panel datasource.
+   * @param unit (optional) The unit of the data.
+   * @param thresholds (optional) An array of threashold values.
    *
    * @method addTarget(target) Adds a target object.
    * @method addTargets(targets) Adds an array of targets.

--- a/grafonnet/cloudwatch.libsonnet
+++ b/grafonnet/cloudwatch.libsonnet
@@ -1,18 +1,18 @@
 {
   /**
-   * Return a CloudWatch Target
+   * Creates a [CloudWatch target](https://grafana.com/docs/grafana/latest/features/datasources/cloudwatch/)
    *
    * @name cloudwatch.target
    *
    * @param region
    * @param namespace
    * @param metric
-   * @param datasource
-   * @param statistic
-   * @param alias
-   * @param highResolution
-   * @param period
-   * @param dimensions
+   * @param datasource (optional)
+   * @param statistic (default: `'Average'`)
+   * @param alias (optional)
+   * @param highResolution (default: `false`)
+   * @param period (default: `'1m'`)
+   * @param dimensions (optional)
 
    * @return Panel target
    */

--- a/grafonnet/dashboard.libsonnet
+++ b/grafonnet/dashboard.libsonnet
@@ -2,7 +2,34 @@ local timepickerlib = import 'timepicker.libsonnet';
 
 {
   /**
+   * Creates a [dashboard](https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/)
+   *
    * @name dashboard.new
+   *
+   * @param title The title of the dashboard
+   * @param editable (default: `false`) Whether the dashboard is editable via Grafana UI.
+   * @param style (default: `'dark'`) Theme of dashboard, `'dark'` or `'light'`
+   * @param tags (optional) Array of tags associated to the dashboard, e.g.`['tag1','tag2']`
+   * @param time_from (default: `'now-6h'`)
+   * @param time_to (default: `'now'`)
+   * @param timezone (default: `'browser'`) Timezone of the dashboard, `'utc'` or `'browser'`
+   * @param refresh (default: `''`) Auto-refresh interval, e.g. `'30s'`
+   * @param timepicker (optional) See timepicker API
+   * @param graphTooltip (default: `'default'`) `'default'` : no shared crosshair or tooltip (0), `'shared_crosshair'`: shared crosshair (1), `'shared_tooltip'`: shared crosshair AND shared tooltip (2)
+   * @param hideControls (default: `false`)
+   * @param schemaVersion (default: `14`) Version of the Grafana JSON schema, incremented each time an update brings changes. `26` for Grafana 7.1.5, `22` for Grafana 6.7.4, `16` for Grafana 5.4.5, `14` for Grafana 4.6.3. etc.
+   * @param uid (default: `''`) Unique dashboard identifier as a string (8-40), that can be chosen by users. Used to identify a dashboard to update when using Grafana REST API.
+   * @param description (optional)
+   *
+   * @method addTemplate(template) Add a template variable
+   * @method addTemplates(templates) Adds an array of template variables
+   * @method addAnnotation(annotation) Add an [annotation](https://grafana.com/docs/grafana/latest/dashboards/annotations/)
+   * @method addPanel(panel,gridPos) Appends a panel, with an optional grid position in grid coordinates, e.g. `gridPos={'x':0, 'y':0, 'w':12, 'h': 9}`
+   * @method addPanels(panels) Appends an array of panels
+   * @method addLink(link) Adds a [dashboard link](https://grafana.com/docs/grafana/latest/linking/dashboard-links/)
+   * @method addRequired(type, name, id, version)
+   * @method addInput(name, label, type, pluginId, pluginName, description, value)
+   * @method addRow(row) Adds a row. This is the legacy row concept from Grafana < 5, when rows were needed for layout. Rows should now be added via `addPanel`.
    */
   new(
     title,

--- a/grafonnet/dashlist.libsonnet
+++ b/grafonnet/dashlist.libsonnet
@@ -1,19 +1,19 @@
 {
   /**
-   * Returns a new dashlist panel that can be added in a row.
+   * Creates a [dashlist panel](https://grafana.com/docs/grafana/latest/panels/visualizations/dashboard-list-panel/).
    * It requires the dashlist panel plugin in grafana, which is built-in.
    *
    * @name dashlist.new
    *
    * @param title The title of the dashlist panel.
-   * @param description Description of the panel
-   * @param query Query to search by
-   * @param tags Tag(s) to search by
-   * @param recent Displays recently viewed dashboards
-   * @param search Description of the panel
-   * @param starred Displays starred dashboards
-   * @param headings Chosen list selection(starred, recently Viewed, search) is shown as a heading
-   * @param limit Set maximum items in a list
+   * @param description (optional) Description of the panel
+   * @param query (optional) Query to search by
+   * @param tags (optional) Array of tag(s) to search by
+   * @param recent (default `true`) Displays recently viewed dashboards
+   * @param search (default `false`) Description of the panel
+   * @param starred (default `false`) Displays starred dashboards
+   * @param headings (default `true`) Chosen list selection(starred, recently Viewed, search) is shown as a heading
+   * @param limit (default `10`) Set maximum items in a list
    * @return A json that represents a dashlist panel
    */
   new(

--- a/grafonnet/elasticsearch.libsonnet
+++ b/grafonnet/elasticsearch.libsonnet
@@ -1,6 +1,16 @@
 {
   /**
+   * Creates an [Elasticsearch target](https://grafana.com/docs/grafana/latest/features/datasources/elasticsearch/)
+   *
    * @name elasticsearch.target
+   *
+   * @param query
+   * @param timeField
+   * @param id (optional)
+   * @param datasource (optional)
+   * @param metrics (optional)
+   * @param bucketAggs (optional)
+   * @param alias (optional)
    */
   target(
     query,

--- a/grafonnet/gauge_panel.libsonnet
+++ b/grafonnet/gauge_panel.libsonnet
@@ -5,30 +5,30 @@
    * @name gaugePanel.new
    *
    * @param title Panel title.
-   * @param description Panel description.
-   * @param transparent Whether to display the panel without a background.
-   * @param datasource Panel datasource.
-   * @param allValues Show all values instead of reducing to one.
-   * @param valueLimit Limit of values in all values mode.
-   * @param reducerFunction Function to use to reduce values to when using single value.
-   * @param fields Fields that should be included in the panel.
-   * @param showThresholdLabels Render the threshold values around the gauge bar.
-   * @param showThresholdMarkers Render the thresholds as an outer bar.
-   * @param unit Panel unit field option.
-   * @param min Leave empty to calculate based on all values.
-   * @param max Leave empty to calculate based on all values.
+   * @param description (optional) Panel description.
+   * @param transparent (default `false`) Whether to display the panel without a background.
+   * @param datasource (optional) Panel datasource.
+   * @param allValues (default `false`) Show all values instead of reducing to one.
+   * @param valueLimit (optional) Limit of values in all values mode.
+   * @param reducerFunction (default `'mean'`) Function to use to reduce values to when using single value.
+   * @param fields (default `''`) Fields that should be included in the panel.
+   * @param showThresholdLabels (default `false`) Render the threshold values around the gauge bar.
+   * @param showThresholdMarkers (default `true`) Render the thresholds as an outer bar.
+   * @param unit (default `'percent'`) Panel unit field option.
+   * @param min (optional) Leave empty to calculate based on all values.
+   * @param max (optional) Leave empty to calculate based on all values.
    * @param decimals Number of decimal places to show.
    * @param displayName Change the field or series name.
-   * @param noValue What to show when there is no value.
-   * @param thresholdsMode 'absolute' or 'percentage'.
-   * @param repeat Name of variable that should be used to repeat this panel.
-   * @param repeatDirection 'h' for horizontal or 'v' for vertical.
-   * @param repeatMaxPerRow Maximum panels per row in repeat mode.
-   * @param pluginVersion Plugin version the panel should be modeled for. This has been tested with the default, '7', and '6.7'.
+   * @param noValue (optional) What to show when there is no value.
+   * @param thresholdsMode (default `'absolute'`) 'absolute' or 'percentage'.
+   * @param repeat (optional) Name of variable that should be used to repeat this panel.
+   * @param repeatDirection (default `'h'`) 'h' for horizontal or 'v' for vertical.
+   * @param repeatMaxPerRow (optional) Maximum panels per row in repeat mode.
+   * @param pluginVersion (default `'7'`) Plugin version the panel should be modeled for. This has been tested with the default, '7', and '6.7'.
    *
    * @method addTarget(target) Adds a target object.
    * @method addTargets(targets) Adds an array of targets.
-   * @method addLink(link) Adds a link. Argument format: `{ title: 'Link Title', url: 'https://...', targetBlank: true }`.
+   * @method addLink(link) Adds a [panel link](https://grafana.com/docs/grafana/latest/linking/panel-links/). Argument format: `{ title: 'Link Title', url: 'https://...', targetBlank: true }`.
    * @method addLinks(links) Adds an array of links.
    * @method addThreshold(step) Adds a threshold step. Argument format: `{ color: 'green', value: 0 }`.
    * @method addThresholds(steps) Adds an array of threshold steps.

--- a/grafonnet/graph_panel.libsonnet
+++ b/grafonnet/graph_panel.libsonnet
@@ -1,60 +1,68 @@
 {
   /**
-   * Returns a new graph panel that can be added in a row.
+   * Creates a [graph panel](https://grafana.com/docs/grafana/latest/panels/visualizations/graph-panel/).
    * It requires the graph panel plugin in grafana, which is built-in.
    *
    * @name graphPanel.new
    *
    * @param title The title of the graph panel.
-   * @param span Width of the panel
-   * @param datasource Datasource
-   * @param fill Fill, integer from 0 to 10
-   * @param linewidth Line Width, integer from 0 to 10
-   * @param decimals Override automatic decimal precision for legend and tooltip. If null, not added to the json output.
-   * @param decimalsY1 Override automatic decimal precision for the first Y axis. If null, use decimals parameter.
-   * @param decimalsY2 Override automatic decimal precision for the second Y axis. If null, use decimals parameter.
-   * @param min_span Min span
-   * @param format Unit of the Y axes
-   * @param formatY1 Unit of the first Y axis
-   * @param formatY2 Unit of the second Y axis
-   * @param min Min of the Y axes
-   * @param max Max of the Y axes
-   * @param labelY1 Label of the first Y axis
-   * @param labelY2 Label of the second Y axis
-   * @param x_axis_mode X axis mode, one of [time, series, histogram]
-   * @param x_axis_values Chosen value of series, one of [avg, min, max, total, count]
-   * @param x_axis_buckets restricts the x axis to this amount of buckets
-   * @param x_axis_min restricts the x axis to display from this value if supplied
-   * @param x_axis_max restricts the x axis to display up to this value if supplied
-   * @param lines Display lines, boolean
-   * @param points Display points, boolean
-   * @param pointradius Radius of the points, allowed values are 0.5 or [1 ... 10] with step 1
-   * @param bars Display bars, boolean
-   * @param staircase Display line as staircase, boolean
-   * @param dashes Display line as dashes
-   * @param stack Stack values
-   * @param repeat Variable used to repeat the graph panel
-   * @param legend_show Show legend
-   * @param legend_values Show values in legend
-   * @param legend_min Show min in legend
-   * @param legend_max Show max in legend
-   * @param legend_current Show current in legend
-   * @param legend_total Show total in legend
-   * @param legend_avg Show average in legend
-   * @param legend_alignAsTable Show legend as table
-   * @param legend_rightSide Show legend to the right
-   * @param legend_sideWidth Legend width
-   * @param legend_sort Sort order of legend
-   * @param legend_sortDesc Sort legend descending
-   * @param aliasColors Define color mappings for graphs
-   * @param thresholds Configuration of graph thresholds
-   * @param logBase1Y Value of logarithm base of the first Y axis
-   * @param logBase2Y Value of logarithm base of the second Y axis
-   * @param transparent Boolean (default: false) If set to true the panel will be transparent
-   * @param value_type Type of tooltip value
-   * @param shared_tooltip Boolean Allow to group or spit tooltips on mouseover within a chart
-   * @param percentage Boolean (defaut: false) show as percentages
-   * @return A json that represents a graph panel
+   * @param description (optional) The description of the panel
+   * @param span (optional) Width of the panel
+   * @param datasource (optional) Datasource
+   * @param fill (default `1`) , integer from 0 to 10
+   * @param linewidth (default `1`) Line Width, integer from 0 to 10
+   * @param decimals (optional) Override automatic decimal precision for legend and tooltip. If null, not added to the json output.
+   * @param decimalsY1 (optional) Override automatic decimal precision for the first Y axis. If null, use decimals parameter.
+   * @param decimalsY2 (optional) Override automatic decimal precision for the second Y axis. If null, use decimals parameter.
+   * @param min_span (optional) Min span
+   * @param format (default `short`) Unit of the Y axes
+   * @param formatY1 (optional) Unit of the first Y axis
+   * @param formatY2 (optional) Unit of the second Y axis
+   * @param min (optional) Min of the Y axes
+   * @param max (optional) Max of the Y axes
+   * @param labelY1 (optional) Label of the first Y axis
+   * @param labelY2 (optional) Label of the second Y axis
+   * @param x_axis_mode (default `'time'`) X axis mode, one of [time, series, histogram]
+   * @param x_axis_values (default `'total'`) Chosen value of series, one of [avg, min, max, total, count]
+   * @param x_axis_buckets (optional) Restricts the x axis to this amount of buckets
+   * @param x_axis_min (optional) Restricts the x axis to display from this value if supplied
+   * @param x_axis_max (optional) Restricts the x axis to display up to this value if supplied
+   * @param lines (default `true`) Display lines
+   * @param points (default `false`) Display points
+   * @param pointradius (default `5`) Radius of the points, allowed values are 0.5 or [1 ... 10] with step 1
+   * @param bars (default `false`) Display bars
+   * @param staircase (default `false`) Display line as staircase
+   * @param dashes (default `false`) Display line as dashes
+   * @param stack (default `false`) Whether to stack values
+   * @param repeat (optional) Name of variable that should be used to repeat this panel.
+   * @param repeatDirection (default `'h'`) 'h' for horizontal or 'v' for vertical.
+   * @param legend_show (default `true`) Show legend
+   * @param legend_values (default `false`) Show values in legend
+   * @param legend_min (default `false`) Show min in legend
+   * @param legend_max (default `false`) Show max in legend
+   * @param legend_current (default `false`) Show current in legend
+   * @param legend_total (default `false`) Show total in legend
+   * @param legend_avg (default `false`) Show average in legend
+   * @param legend_alignAsTable (default `false`) Show legend as table
+   * @param legend_rightSide (default `false`) Show legend to the right
+   * @param legend_sideWidth (optional) Legend width
+   * @param legend_sort (optional) Sort order of legend
+   * @param legend_sortDesc (optional) Sort legend descending
+   * @param aliasColors (optional) Define color mappings for graphs
+   * @param thresholds (optional) An array of graph thresholds
+   * @param logBase1Y (default `1`) Value of logarithm base of the first Y axis
+   * @param logBase2Y (default `1`) Value of logarithm base of the second Y axis
+   * @param transparent (default `false`) Whether to display the panel without a background.
+   * @param value_type (default `'individual'`) Type of tooltip value
+   * @param shared_tooltip (default `true`) Allow to group or spit tooltips on mouseover within a chart
+   * @param percentage (defaut: false) show as percentages
+   *
+   * @method addTarget(target) Adds a target object.
+   * @method addTargets(targets) Adds an array of targets.
+   * @method addSeriesOverride(override)
+   * @method addYaxis(format,min,max,label,show,logBase,decimals) Adds a Y axis to the graph
+   * @method addAlert(alert) Adds an alert
+   * @method addLink(link) Adds a [panel link](https://grafana.com/docs/grafana/latest/linking/panel-links/)
    */
   new(
     title,

--- a/grafonnet/graphite.libsonnet
+++ b/grafonnet/graphite.libsonnet
@@ -1,14 +1,14 @@
 {
   /**
-   * Return an Graphite Target
+   * Creates a [Graphite target](https://grafana.com/docs/grafana/latest/features/datasources/graphite/)
    *
    * @name graphite.target
    *
    * @param target Graphite Query. Nested queries are possible by adding the query reference (refId).
-   * @param targetFull Expanding the @target. Used in nested queries.
-   * @param hide Disable query on graph.
-   * @param textEditor Enable raw query mode.
-   * @param datasource Datasource.
+   * @param targetFull (optional) Expanding the @target. Used in nested queries.
+   * @param hide (default `false`) Disable query on graph.
+   * @param textEditor (default `false`) Enable raw query mode.
+   * @param datasource (optional) Datasource.
 
    * @return Panel target
    */

--- a/grafonnet/heatmap_panel.libsonnet
+++ b/grafonnet/heatmap_panel.libsonnet
@@ -1,46 +1,50 @@
 {
   /**
-   * Returns a heatmap panel.
+   * Creates a [heatmap panel](https://grafana.com/docs/grafana/latest/panels/visualizations/heatmap/).
    * Requires the heatmap panel plugin in Grafana, which is built-in.
    *
    * @name heatmapPanel.new
    *
    * @param title The title of the heatmap panel
-   * @param datasource Datasource
-   * @param min_span Min span
-   * @param span Width of the panel
-   * @param cards_cardPadding How much padding to put between bucket cards
-   * @param cards_cardRound How much rounding should be applied to the bucket card shape
-   * @param color_cardColor Hex value of color used when color_colorScheme is 'opacity'
-   * @param color_colorScale How to scale the color range, 'linear' or 'sqrt'
-   * @param color_colorScheme TODO: document
-   * @param color_exponent TODO: document
-   * @param color_max The value for the end of the color range
-   * @param color_min The value for the beginning of the color range
-   * @param color_mode How to display difference in frequency with color, default 'opacity'
-   * @param dataFormat How to format the data, default is 'timeseries'
-   * @param highlightCards TODO: document
-   * @param hideZeroBuckets Whether or not to hide empty buckets, default is false
-   * @param legend_show Show legend
-   * @param minSpan Minimum span of the panel when repeated on a template variable
-   * @param repeat Variable used to repeat the heatmap panel
-   * @param repeatDirection Which direction to repeat the panel, 'h' for horizontal and 'v' for vertically
-   * @param tooltipDecimals The number of decimal places to display in the tooltip
-   * @param tooltip_show Whether or not to display a tooltip when hovering over the heatmap
-   * @param tooltip_showHistogram Whether or not to display a histogram in the tooltip
-   * @param xAxis_show Whether or not to show the X axis, default true
-   * @param xBucketNumber Number of buckets for the X axis
-   * @param xBucketSize Size of X axis buckets. Number or interval(10s, 15h, etc.) Has priority over xBucketNumber
-   * @param yAxis_decimals Override automatic decimal precision for the Y axis
-   * @param yAxis_format Unit of the Y axis
-   * @param yAxis_logBase Only if dataFormat is 'timeseries'
-   * @param yAxis_min Only if dataFormat is 'timeseries', min of the Y axis
-   * @param yAxis_max Only if dataFormat is 'timeseries', max of the Y axis
-   * @param yAxis_show Whether or not to show the Y axis
-   * @param yAxis_splitFactor TODO: document
-   * @param yBucketBound Which bound ('lower' or 'upper') of the bucket to use, default 'auto'
-   * @param yBucketNumber Number of buckets for the Y axis
-   * @param yBucketSize Size of Y axis buckets. Has priority over yBucketNumber
+   * @param description (optional) Description of panel
+   * @param datasource (optional) Datasource
+   * @param min_span (optional) Min span
+   * @param span (optional) Width of the panel
+   * @param cards_cardPadding (optional) How much padding to put between bucket cards
+   * @param cards_cardRound (optional) How much rounding should be applied to the bucket card shape
+   * @param color_cardColor (default `'#b4ff00'`) Hex value of color used when color_colorScheme is 'opacity'
+   * @param color_colorScale (default `'sqrt'`) How to scale the color range, 'linear' or 'sqrt'
+   * @param color_colorScheme (default `'interpolateOranges'`) TODO: document
+   * @param color_exponent (default `0.5`) TODO: document
+   * @param color_max (optional) The value for the end of the color range
+   * @param color_min (optional) The value for the beginning of the color range
+   * @param color_mode (default `'spectrum'`) How to display difference in frequency with color
+   * @param dataFormat (default `'timeseries'`) How to format the data
+   * @param highlightCards (default `true`) TODO: document
+   * @param hideZeroBuckets (default `false`) Whether or not to hide empty buckets, default is false
+   * @param legend_show (default `false`) Show legend
+   * @param minSpan (optional) Minimum span of the panel when repeated on a template variable
+   * @param repeat (optional) Variable used to repeat the heatmap panel
+   * @param repeatDirection (optional) Which direction to repeat the panel, 'h' for horizontal and 'v' for vertically
+   * @param tooltipDecimals (optional) The number of decimal places to display in the tooltip
+   * @param tooltip_show (default `true`) Whether or not to display a tooltip when hovering over the heatmap
+   * @param tooltip_showHistogram (default `false`) Whether or not to display a histogram in the tooltip
+   * @param xAxis_show (default `true`) Whether or not to show the X axis, default true
+   * @param xBucketNumber (optional) Number of buckets for the X axis
+   * @param xBucketSize (optional) Size of X axis buckets. Number or interval(10s, 15h, etc.) Has priority over xBucketNumber
+   * @param yAxis_decimals (optional) Override automatic decimal precision for the Y axis
+   * @param yAxis_format (default `'short'`) Unit of the Y axis
+   * @param yAxis_logBase (default `1`) Only if dataFormat is 'timeseries'
+   * @param yAxis_min (optional) Only if dataFormat is 'timeseries', min of the Y axis
+   * @param yAxis_max (optional) Only if dataFormat is 'timeseries', max of the Y axis
+   * @param yAxis_show (default `true`) Whether or not to show the Y axis
+   * @param yAxis_splitFactor (optional) TODO: document
+   * @param yBucketBound (default `'auto'`) Which bound ('lower' or 'upper') of the bucket to use
+   * @param yBucketNumber (optional) Number of buckets for the Y axis
+   * @param yBucketSize (optional) Size of Y axis buckets. Has priority over yBucketNumber
+   *
+   * @method addTarget(target) Adds a target object.
+   * @method addTargets(targets) Adds an array of targets.
    */
   new(
     title,

--- a/grafonnet/influxdb.libsonnet
+++ b/grafonnet/influxdb.libsonnet
@@ -1,24 +1,24 @@
 {
   /**
-   * Return an InfluxDB Target
+   * Creates an [InfluxDB target](https://grafana.com/docs/grafana/latest/features/datasources/influxdb/)
    *
    * @name influxdb.target
    *
    * @param query Raw InfluxQL statement
    *
-   * @param alias 'Alias By' pattern
-   * @param datasource Datasource
-   * @param hide Disable query on graph
+   * @param alias (optional) 'Alias By' pattern
+   * @param datasource (optional) Datasource
+   * @param hide (optional) Disable query on graph
    *
-   * @param rawQuery Enable/disable raw query mode
+   * @param rawQuery (optional) Enable/disable raw query mode
    *
-   * @param policy Tagged query 'From' policy
-   * @param measurement Tagged query 'From' measurement
-   * @param group_time 'Group by' time condition (if set to null, do not groups by time)
-   * @param group_tags 'Group by' tags list
-   * @param fill 'Group by' missing values fill mode (works only with 'Group by time()')
+   * @param policy (default: `'default'`) Tagged query 'From' policy
+   * @param measurement (optional) Tagged query 'From' measurement
+   * @param group_time (default: `'$__interval'`) 'Group by' time condition (if set to null, do not groups by time)
+   * @param group_tags (optional) 'Group by' tags list
+   * @param fill (default: `'none'`) 'Group by' missing values fill mode (works only with 'Group by time()')
    *
-   * @param resultFormat Format results as 'Time series' or 'Table'
+   * @param resultFormat (default: `'time_series'`) Format results as 'Time series' or 'Table'
    *
    * @return Panel target
    */

--- a/grafonnet/link.libsonnet
+++ b/grafonnet/link.libsonnet
@@ -1,5 +1,17 @@
 {
   /**
+   * Creates [links](https://grafana.com/docs/grafana/latest/linking/linking-overview/) to navigate to other dashboards.
+   *
+   * @param title Human-readable label for the link.
+   * @param tags Limits the linked dashboards to only the ones with the corresponding tags. Otherwise, Grafana includes links to all other dashboards.
+   * @param asDropdown (default: `true`) Whether to use a dropdown (with an optional title). If `false`, displays the dashboard links side by side across the top of dashboard.
+   * @param includeVars (default: `false`) Whether to include template variables currently used as query parameters in the link. Any matching templates in the linked dashboard are set to the values from the link
+   * @param keepTime (default: `false`) Whether to include the current dashboard time range in the link (e.g. from=now-3h&to=now)
+   * @param icon (default: `'external link'`) Icon displayed with the link.
+   * @param url (default: `''`) URL of the link
+   * @param targetBlank (default: `false`) Whether the link will open in a new window.
+   * @param type (default: `'dashboards'`)
+   *
    * @name link.dashboards
    */
   dashboards(

--- a/grafonnet/log_panel.libsonnet
+++ b/grafonnet/log_panel.libsonnet
@@ -1,18 +1,20 @@
 {
   /**
-   * Returns a new log panel that can be added in a row.
+   * Creates a [log panel](https://grafana.com/docs/grafana/latest/panels/visualizations/logs-panel/).
    * It requires the log panel plugin in grafana, which is built-in.
    *
    * @name logPanel.new
    *
-   * @param title The title of the log panel.
-   * @param span Width of the panel
-   * @param datasource Datasource
-   * @showLabels boolean to show or hide labels
-   * @showTime boolean to show or hide time for each line
-   * @wrapLogMessage true to wrap log line to the next line
-   * @sortOrder sort log by time (can be Descending or Ascending )
-   * @return A json that represents a log panel
+   * @param title (default `''`) The title of the log panel.
+   * @param span (optional) Width of the panel
+   * @param datasource (optional) Datasource
+   * @showLabels (default `false`) Whether to show or hide labels
+   * @showTime (default `true`) Whether to show or hide time for each line
+   * @wrapLogMessage (default `true`) Whether to wrap log line to the next line
+   * @sortOrder (default `'Descending'`) sort log by time (can be 'Descending' or 'Ascending' )
+   *
+   * @method addTarget(target) Adds a target object
+   * @method addTargets(targets) Adds an array of targets
    */
   new(
     title='',

--- a/grafonnet/loki.libsonnet
+++ b/grafonnet/loki.libsonnet
@@ -1,6 +1,11 @@
 {
   /**
+   * Creates a [Loki target](https://grafana.com/docs/grafana/latest/features/datasources/loki/)
+   *
    * @name loki.target
+   *
+   * @param expr
+   * @param hide (optional) Disable query on graph.
    */
   target(
     expr,

--- a/grafonnet/pie_chart_panel.libsonnet
+++ b/grafonnet/pie_chart_panel.libsonnet
@@ -1,25 +1,28 @@
 {
   /**
-   * Returns a new pie chart panel that can be added in a row.
-   * It requires the pie chart panel plugin in grafana, which needs to be explicitly installed.
+   * Creates a pie chart panel.
+   * It requires the [pie chart panel plugin in grafana](https://grafana.com/grafana/plugins/grafana-piechart-panel),
+   * which needs to be explicitly installed.
    *
    * @name pieChartPanel.new
    *
    * @param title The title of the pie chart panel.
-   * @param description Description of the panel
-   * @param span Width of the panel
-   * @param min_span Min span
-   * @param datasource Datasource
-   * @param aliasColors Define color mappings
-   * @param pieType Type of pie chart (one of pie or donut)
-   * @param showLegend Show legend
-   * @param showLegendPercentage Show percentage values in the legend
-   * @param legendType Type of legend (one of 'Right side', 'Under graph' or 'On graph')
-   * @param valueName Type of tooltip value
-   * @param repeat Variable used to repeat the pie chart
-   * @param repeatDirection Which direction to repeat the panel, 'h' for horizontal and 'v' for vertical
-   * @param maxPerRow Number of panels to display when repeated. Used in combination with repeat.
+   * @param description (default `''`) Description of the panel
+   * @param span (optional) Width of the panel
+   * @param min_span (optional) Min span
+   * @param datasource (optional) Datasource
+   * @param aliasColors (optional) Define color mappings
+   * @param pieType (default `'pie'`) Type of pie chart (one of pie or donut)
+   * @param showLegend (default `true`) Show legend
+   * @param showLegendPercentage (default `true`) Show percentage values in the legend
+   * @param legendType (default `'Right side'`) Type of legend (one of 'Right side', 'Under graph' or 'On graph')
+   * @param valueName (default `'current') Type of tooltip value
+   * @param repeat (optional) Variable used to repeat the pie chart
+   * @param repeatDirection (optional) Which direction to repeat the panel, 'h' for horizontal and 'v' for vertical
+   * @param maxPerRow (optional) Number of panels to display when repeated. Used in combination with repeat.
    * @return A json that represents a pie chart panel
+   *
+   * @method addTarget(target) Adds a target object.
    */
   new(
     title,

--- a/grafonnet/pluginlist.libsonnet
+++ b/grafonnet/pluginlist.libsonnet
@@ -6,8 +6,8 @@
    * @name pluginlist.new
    *
    * @param title The title of the pluginlist panel.
-   * @param description Description of the panel
-   * @param limit Set maximum items in a list
+   * @param description (optional) Description of the panel
+   * @param limit (optional) Set maximum items in a list
    * @return A json that represents a pluginlist panel
    */
   new(

--- a/grafonnet/prometheus.libsonnet
+++ b/grafonnet/prometheus.libsonnet
@@ -1,6 +1,6 @@
 {
   /**
-   * [Prometheus target](https://grafana.com/docs/grafana/latest/features/datasources/prometheus/)
+   * Creates a [Prometheus target](https://grafana.com/docs/grafana/latest/features/datasources/prometheus/)
    * to be added to panels.
    *
    * @name prometheus.target
@@ -10,7 +10,7 @@
    * @param intervalFactor (default `2`)
    * @param legendFormat (default `''`) Controls the name of the time series, using name or pattern. For example `{{hostname}}` is replaced with the label value for the label `hostname`.
    * @param datasource (optional) Name of the Prometheus datasource. Leave by default otherwise.
-   * @param interval (optional)
+   * @param interval (optional) Time span used to aggregate or group data points by time. By default Grafana uses an automatic interval calculated based on the width of the graph.
    * @param instant (optional) Perform an "instant" query, to return only the latest value that Prometheus has scraped for the requested time series. Instant queries return results much faster than normal range queries. Use them to look up label sets.
    * @param hide (optional) Set to `true` to hide the target from the panel.
    *

--- a/grafonnet/row.libsonnet
+++ b/grafonnet/row.libsonnet
@@ -1,6 +1,18 @@
 {
   /**
+   * Creates a [row](https://grafana.com/docs/grafana/latest/features/dashboard/dashboards/#rows).
+   * Rows are logical dividers within a dashboard and used to group panels together.
+   *
    * @name row.new
+   *
+   * @param title The title of the row.
+   * @param showTitle (default `true` if title is set) Whether to show the row title
+   * @paral titleSize (default `'h6'`) The size of the title
+   * @param collapse (default `false`) The initial state of the row when opening the dashboard. Panels in a collapsed row are not load until the row is expanded.
+   * @param repeat (optional) Name of variable that should be used to repeat this row. It is recommended to use the variable in the row title as well.
+   *
+   * @method addPanels(panels) Appends an array of nested panels
+   * @method addPanel(panel,gridPos) Appends a nested panel, with an optional grid position in grid coordinates, e.g. `gridPos={'x':0, 'y':0, 'w':12, 'h': 9}`
    */
   new(
     title='Dashboard Row',

--- a/grafonnet/singlestat.libsonnet
+++ b/grafonnet/singlestat.libsonnet
@@ -1,6 +1,49 @@
 {
   /**
+   * Creates a singlestat panel.
+   *
    * @name singlestat.new
+   *
+   * @param title The title of the singlestat panel.
+   * @param format (default `'none'`) Unit
+   * @param description (default `''`)
+   * @param interval (optional)
+   * @param height (optional)
+   * @param datasource (optional)
+   * @param span (optional)
+   * @param min_span (optional)
+   * @param decimals (optional)
+   * @param valueName (default `'avg'`)
+   * @param valueFontSize (default `'80%'`)
+   * @param prefixFontSize (default `'50%'`)
+   * @param postfixFontSize (default `'50%'`)
+   * @param mappingType (default `1`)
+   * @param repeat (optional)
+   * @param repeatDirection (optional)
+   * @param prefix (default `''`)
+   * @param postfix (default `''`)
+   * @param colors (default `['#299c46','rgba(237, 129, 40, 0.89)','#d44a3a']`)
+   * @param colorBackground (default `false`)
+   * @param colorValue (default `false`)
+   * @param thresholds (default `''`)
+   * @param valueMaps (default `{value: 'null',op: '=',text: 'N/A'}`)
+   * @param rangeMaps (default `{value: 'null',op: '=',text: 'N/A'}`)
+   * @param transparent (optional)
+   * @param sparklineFillColor (default `'rgba(31, 118, 189, 0.18)'`)
+   * @param sparklineFull (default `false`)
+   * @param sparklineLineColor (default `'rgb(31, 120, 193)'`)
+   * @param sparklineShow (default `false`)
+   * @param gaugeShow (default `false`)
+   * @param gaugeMinValue (default `0`)
+   * @param gaugeMaxValue (default `100`)
+   * @param gaugeThresholdMarkers (default `true`)
+   * @param gaugeThresholdLabels (default `false`)
+   * @param timeFrom (optional)
+   * @param links (optional)
+   * @param tableColumn (default `''`)
+   * @param maxPerRow (optional)
+   *
+   * @method addTarget(target) Adds a target object.
    */
   new(
     title,

--- a/grafonnet/sql.libsonnet
+++ b/grafonnet/sql.libsonnet
@@ -1,6 +1,12 @@
 {
   /**
+   * Creates an SQL target.
+   *
    * @name sql.target
+   *
+   * @param rawSql The SQL query
+   * @param datasource (optional)
+   * @param format (default `'time_series'`)
    */
   target(
     rawSql,

--- a/grafonnet/stat_panel.libsonnet
+++ b/grafonnet/stat_panel.libsonnet
@@ -5,34 +5,34 @@
    * @name statPanel.new
    *
    * @param title Panel title.
-   * @param description Panel description.
-   * @param transparent Whether to display the panel without a background.
-   * @param datasource Panel datasource.
-   * @param allValues Show all values instead of reducing to one.
-   * @param valueLimit Limit of values in all values mode.
-   * @param reducerFunction Function to use to reduce values to when using single value.
-   * @param fields Fields that should be included in the panel.
-   * @param orientation Stacking direction in case of multiple series or fields.
-   * @param colorMode 'value' or 'background'.
-   * @param graphMode 'none' or 'area' to enable sparkline mode.
-   * @param justifyMode 'auto' or 'center'.
-   * @param unit Panel unit field option.
-   * @param min Leave empty to calculate based on all values.
-   * @param max Leave empty to calculate based on all values.
-   * @param decimals Number of decimal places to show.
-   * @param displayName Change the field or series name.
-   * @param noValue What to show when there is no value.
-   * @param thresholdsMode 'absolute' or 'percentage'.
-   * @param repeat Name of variable that should be used to repeat this panel.
-   * @param repeatDirection 'h' for horizontal or 'v' for vertical.
-   * @param repeatMaxPerRow Maximum panels per row in repeat mode.
-   * @param pluginVersion Plugin version the panel should be modeled for. This has been tested with the default, '7', and '6.7'.
+   * @param description (optional) Panel description.
+   * @param transparent (default `false`) Whether to display the panel without a background.
+   * @param datasource (optional) Panel datasource.
+   * @param allValues (default `false`) Show all values instead of reducing to one.
+   * @param valueLimit (optional) Limit of values in all values mode.
+   * @param reducerFunction (default `'mean'`) Function to use to reduce values to when using single value.
+   * @param fields (default `''`) Fields that should be included in the panel.
+   * @param orientation (default `'auto'`) Stacking direction in case of multiple series or fields.
+   * @param colorMode (default `'value'`) 'value' or 'background'.
+   * @param graphMode (default `'area'`) 'none' or 'area' to enable sparkline mode.
+   * @param justifyMode (default `'auto'`) 'auto' or 'center'.
+   * @param unit (default `'none'`) Panel unit field option.
+   * @param min (optional) Leave empty to calculate based on all values.
+   * @param max (optional) Leave empty to calculate based on all values.
+   * @param decimals (optional) Number of decimal places to show.
+   * @param displayName (optional) Change the field or series name.
+   * @param noValue (optional) What to show when there is no value.
+   * @param thresholdsMode (default `'absolute'`) 'absolute' or 'percentage'.
+   * @param repeat (optional) Name of variable that should be used to repeat this panel.
+   * @param repeatDirection (default `'h'`) 'h' for horizontal or 'v' for vertical.
+   * @param repeatMaxPerRow (optional) Maximum panels per row in repeat mode.
+   * @param pluginVersion (default `'7'`) Plugin version the panel should be modeled for. This has been tested with the default, '7', and '6.7'.
    *
    * @method addTarget(target) Adds a target object.
    * @method addTargets(targets) Adds an array of targets.
-   * @method addLink(link) Adds a link. Argument format: `{ title: 'Link Title', url: 'https://...', targetBlank: true }`.
+   * @method addLink(link) Adds a [panel link](https://grafana.com/docs/grafana/latest/linking/panel-links/). Argument format: `{ title: 'Link Title', url: 'https://...', targetBlank: true }`.
    * @method addLinks(links) Adds an array of links.
-   * @method addThreshold(step) Adds a threshold step. Argument format: `{ color: 'green', value: 0 }`.
+   * @method addThreshold(step) Adds a [threshold](https://grafana.com/docs/grafana/latest/panels/thresholds/) step. Argument format: `{ color: 'green', value: 0 }`.
    * @method addThresholds(steps) Adds an array of threshold steps.
    * @method addMapping(mapping) Adds a value mapping.
    * @method addMappings(mappings) Adds an array of value mappings.

--- a/grafonnet/table_panel.libsonnet
+++ b/grafonnet/table_panel.libsonnet
@@ -1,23 +1,29 @@
 {
   /**
-   * Returns a new table panel that can be added in a row.
+   * Creates a [table panel](https://grafana.com/docs/grafana/latest/panels/visualizations/table-panel/) that can be added in a row.
    * It requires the table panel plugin in grafana, which is built-in.
    *
    * @name table.new
    *
    * @param title The title of the graph panel.
-   * @param span Width of the panel
-   * @param height Height of the panel
-   * @param description Description of the panel
-   * @param datasource Datasource
-   * @param min_span Min span
-   * @param styles Styles for the panel
-   * @param columns Columns for the panel
-   * @param sort Sorting instruction for the panel
-   * @param transform allow table manipulation to present data as desired
-   * @param transparent Boolean (default: false) If set to true the panel will be transparent
-   * @param links Set of links for the panel.
+   * @param description (optional) Description of the panel
+   * @param span (optional)  Width of the panel
+   * @param height (optional)  Height of the panel
+   * @param datasource (optional) Datasource
+   * @param min_span (optional)  Min span
+   * @param styles (optional) Array of styles for the panel
+   * @param columns (optional) Array of columns for the panel
+   * @param sort (optional) Sorting instruction for the panel
+   * @param transform (optional) Allow table manipulation to present data as desired
+   * @param transparent (default: 'false') Whether to display the panel without a background
+   * @param links (optional) Array of links for the panel.
    * @return A json that represents a table panel
+   *
+   * @method addTarget(target) Adds a target object
+   * @method addTargets(targets) Adds an array of targets
+   * @method addColumn(field, style) Adds a column
+   * @method hideColumn(field) Hides a column
+   * @method addLink(link) Adds a link
    */
   new(
     title,

--- a/grafonnet/template.libsonnet
+++ b/grafonnet/template.libsonnet
@@ -1,11 +1,10 @@
 {
   /**
-   * Returns a new template that can be added to a dashboard.
-   * See what's a [template](https://grafana.com/docs/grafana/latest/variables/templates-and-variables/#templates).
+   * Creates a [template](https://grafana.com/docs/grafana/latest/variables/templates-and-variables/#templates) that can be added to a dashboard.
    *
    * @name template.new
    *
-   * @param name Name of variable
+   * @param name Name of variable.
    * @param datasource Template [datasource](https://grafana.com/docs/grafana/latest/variables/variable-types/add-data-source-variable/)
    * @param query [Query expression](https://grafana.com/docs/grafana/latest/variables/variable-types/add-query-variable/) for the datasource.
    * @param label (optional) Display name of the variable dropdown. If null, then the dropdown label will be the variable name.

--- a/grafonnet/text.libsonnet
+++ b/grafonnet/text.libsonnet
@@ -9,8 +9,8 @@
    * @param datasource (optional) Panel datasource.
    * @param span (optional)
    * @param content (default `''`)
-   * @param mode (default `'markdown'`)
-   * @param transparent (optional)
+   * @param mode (default `'markdown'`) Rendering of the content: 'markdown','html', ...
+   * @param transparent (optional) Whether to display the panel without a background.
    * @param repeat (optional) Name of variable that should be used to repeat this panel.
    * @param repeatDirection (default `'h'`) 'h' for horizontal or 'v' for vertical.
    * @param repeatMaxPerRow (optional) Maximum panels per row in repeat mode.

--- a/grafonnet/timepicker.libsonnet
+++ b/grafonnet/timepicker.libsonnet
@@ -1,6 +1,11 @@
 {
   /**
+   * Creates a Timepicker
+   *
    * @name timepicker.new
+   *
+   * @param refresh_intervals (default: `['5s','10s','30s','1m','5m','15m','30m','1h','2h','1d']`) Array of time durations
+   * @param time_options (default: `['5m','15m','1h','6h','12h','24h','2d','7d','30d']`) Array of time durations
    */
   new(
     refresh_intervals=[


### PR DESCRIPTION
I've continued the work started by @corentinaltepe in #252, with info I wish I found in the doc when I started using grafonnet-lib

- Add missing JSDoc for dashboard.new, row.new and link.dashboards
- Add default values and whether a parameter is optional in existing docs
- Link to Grafana documentation when applicable

This is based on my limited knowledge of Grafana, and I've left some parameters description empty when I didn't know about an object or parameter.