### PR TITLE
Add field title for gauge 6.6.0

### DIFF
--- a/grafonnet/gauge_panel.libsonnet
+++ b/grafonnet/gauge_panel.libsonnet
@@ -15,6 +15,7 @@
    * @param showThresholdLabels (default `false`) Render the threshold values around the gauge bar.
    * @param showThresholdMarkers (default `true`) Render the thresholds as an outer bar.
    * @param unit (default `'percent'`) Panel unit field option.
+   * @param fieldTitle (optional) Field title. May contain template variables (e.g. ${__series.name}).
    * @param min (optional) Leave empty to calculate based on all values.
    * @param max (optional) Leave empty to calculate based on all values.
    * @param decimals Number of decimal places to show.
@@ -50,6 +51,7 @@
     showThresholdLabels=false,
     showThresholdMarkers=true,
     unit='percent',
+    fieldTitle=null,
     min=0,
     max=100,
     decimals=null,
@@ -177,6 +179,7 @@
               mode: thresholdsMode,
               steps: [],
             },
+            [if fieldTitle != null then 'title']: fieldTitle,
             mappings: [],
             links: [],
           },

--- a/tests/gauge_panel/test.jsonnet
+++ b/tests/gauge_panel/test.jsonnet
@@ -46,4 +46,10 @@ local gaugePanel = grafana.gaugePanel;
       { color: 'yellow', value: 50 },
       { color: 'red', value: 80 },
     ]),
+  field_title_grafana6:
+    gaugePanel.new(
+      '',
+      pluginVersion='6.6.0',
+      fieldTitle='${__series.name}',
+    ),
 }

--- a/tests/gauge_panel/test_compiled.json
+++ b/tests/gauge_panel/test_compiled.json
@@ -147,6 +147,38 @@
       "transparent": false,
       "type": "gauge"
    },
+   "field_title_grafana6": {
+      "datasource": null,
+      "links": [ ],
+      "options": {
+         "fieldOptions": {
+            "calcs": [
+               "mean"
+            ],
+            "defaults": {
+               "links": [ ],
+               "mappings": [ ],
+               "max": 100,
+               "min": 0,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [ ]
+               },
+               "title": "${__series.name}",
+               "unit": "percent"
+            },
+            "fields": "",
+            "values": false
+         },
+         "showThresholdLabels": false,
+         "showThresholdMarkers": true
+      },
+      "pluginVersion": "6.6.0",
+      "targets": [ ],
+      "title": "",
+      "transparent": false,
+      "type": "gauge"
+   },
    "thresholds": {
       "datasource": null,
       "fieldConfig": {


### PR DESCRIPTION
fieldOptions.defaults.title is a parameter similar to displayName in 7.x.x.

![image](https://user-images.githubusercontent.com/20455996/93305416-28220880-f807-11ea-9696-43cb55c027b9.png)
