### PR TITLE
Add number of decimal places to set for bar_gauge_panel

### DIFF
--- a/grafonnet/bar_gauge_panel.libsonnet
+++ b/grafonnet/bar_gauge_panel.libsonnet
@@ -9,6 +9,7 @@
    * @param datasource (optional) Panel datasource.
    * @param unit (optional) The unit of the data.
    * @param thresholds (optional) An array of threashold values.
+   * @param decimals (optional)  Number of decimal places to show.
    *
    * @method addTarget(target) Adds a target object.
    * @method addTargets(targets) Adds an array of targets.
@@ -19,6 +20,7 @@
     datasource=null,
     unit=null,
     thresholds=[],
+    decimals=null,
   ):: {
     type: 'bargauge',
     title: title,
@@ -28,6 +30,7 @@
     ],
     fieldConfig: {
       defaults: {
+	[if decimals != null then 'decimals']: decimals,
         unit: unit,
         thresholds: {
           mode: 'absolute',

--- a/grafonnet/bar_gauge_panel.libsonnet
+++ b/grafonnet/bar_gauge_panel.libsonnet
@@ -30,7 +30,7 @@
     ],
     fieldConfig: {
       defaults: {
-	[if decimals != null then 'decimals']: decimals,
+        [if decimals != null then 'decimals']: decimals,
         unit: unit,
         thresholds: {
           mode: 'absolute',


### PR DESCRIPTION
Hello,

I am using grafana version: v7.1.5 (9893b8c53d)
In the bar_gauge_panel.libsonnet i did not see any parameter to add number of decimal places, so adding it