### PR TITLE
Allow set an orientantion and displayMode for BarGuage 

### DIFF
--- a/grafonnet/bar_gauge_panel.libsonnet
+++ b/grafonnet/bar_gauge_panel.libsonnet
@@ -19,6 +19,8 @@
     datasource=null,
     unit=null,
     thresholds=[],
+    orientation=null,
+    displayMode=null,
   ):: {
     type: 'bargauge',
     title: title,
@@ -43,5 +45,17 @@
       targets+: [target { refId: std.char(std.codepoint('A') + nextTarget) }],
     },
     addTargets(targets):: std.foldl(function(p, t) p.addTarget(t), targets, self),
+    "options": {
+    "reduceOptions": {
+      "values": false,
+      "calcs": [
+        "mean"
+      ],
+      "fields": ""
+    },
+    "orientation": orientation,
+    "displayMode": displayMode,
+    "showUnfilled": true
+  },
   },
 }

--- a/grafonnet/bar_gauge_panel.libsonnet
+++ b/grafonnet/bar_gauge_panel.libsonnet
@@ -47,17 +47,17 @@
       targets+: [target { refId: std.char(std.codepoint('A') + nextTarget) }],
     },
     addTargets(targets):: std.foldl(function(p, t) p.addTarget(t), targets, self),
-    "options": {
-    "reduceOptions": {
-      "values": false,
-      "calcs": [
-        "mean"
-      ],
-      "fields": ""
+    options: {
+      reduceOptions: {
+        values: false,
+        calcs: [
+          'mean',
+        ],
+        fields: '',
+      },
+      [if orientation != null then 'orientation']: orientation,
+      [if displayMode != null then 'displayMode']: displayMode,
+      showUnfilled: true,
     },
-    [if orientation !=null then 'orientation']: orientation,
-    [if displayMode !=null then 'displayMode']: displayMode,
-    "showUnfilled": true
-  },
   },
 }

--- a/grafonnet/bar_gauge_panel.libsonnet
+++ b/grafonnet/bar_gauge_panel.libsonnet
@@ -9,8 +9,12 @@
    * @param datasource (optional) Panel datasource.
    * @param unit (optional) The unit of the data.
    * @param thresholds (optional) An array of threashold values.
+   * @param values (optional) Bool if show values
+   * @param calcs (optional) An array of type of calculation
+   * @param fields (optional) string - fields that should be included in the panel
    * @param orientation (optional) string (horizontal or vertical)
    * @param displayMode (optional) string (eg. lcd)
+   * @param showUnfilled (optional) bool if showUnfilled
    *
    * @method addTarget(target) Adds a target object.
    * @method addTargets(targets) Adds an array of targets.
@@ -21,8 +25,12 @@
     datasource=null,
     unit=null,
     thresholds=[],
-    orientation=null,
-    displayMode=null,
+    values=false,
+    calcs=['mean'],
+    fields='',
+    orientation='auto',
+    displayMode='gradient',
+    showUnfilled=true,
   ):: {
     type: 'bargauge',
     title: title,
@@ -49,15 +57,13 @@
     addTargets(targets):: std.foldl(function(p, t) p.addTarget(t), targets, self),
     options: {
       reduceOptions: {
-        values: false,
-        calcs: [
-          'mean',
-        ],
-        fields: '',
+        values: values,
+        calcs: calcs,
+        fields: fields,
       },
-      [if orientation != null then 'orientation']: orientation,
-      [if displayMode != null then 'displayMode']: displayMode,
-      showUnfilled: true,
+      orientation: orientation,
+      displayMode: displayMode,
+      showUnfilled: showUnfilled,
     },
   },
 }

--- a/grafonnet/bar_gauge_panel.libsonnet
+++ b/grafonnet/bar_gauge_panel.libsonnet
@@ -55,8 +55,8 @@
       ],
       "fields": ""
     },
-    "orientation": orientation,
-    "displayMode": displayMode,
+    [if orientation !=null then 'orientation']: orientation,
+    [if displayMode !=null then 'displayMode']: displayMode,
     "showUnfilled": true
   },
   },

--- a/grafonnet/bar_gauge_panel.libsonnet
+++ b/grafonnet/bar_gauge_panel.libsonnet
@@ -9,6 +9,8 @@
    * @param datasource (optional) Panel datasource.
    * @param unit (optional) The unit of the data.
    * @param thresholds (optional) An array of threashold values.
+   * @param orientation (optional) string (horizontal or vertical)
+   * @param displayMode (optional) string (eg. lcd)
    *
    * @method addTarget(target) Adds a target object.
    * @method addTargets(targets) Adds an array of targets.


### PR DESCRIPTION
Hi,

In the bar_gauge_panel.libsonnet i did not see any option to set an orientation or displayMode to configure it, so adding it




