### PR TITLE
Enhance dashboard to support adding multiple dashboard links

### DIFF
--- a/grafonnet/dashboard.libsonnet
+++ b/grafonnet/dashboard.libsonnet
@@ -27,6 +27,7 @@ local timepickerlib = import 'timepicker.libsonnet';
    * @method addPanel(panel,gridPos) Appends a panel, with an optional grid position in grid coordinates, e.g. `gridPos={'x':0, 'y':0, 'w':12, 'h': 9}`
    * @method addPanels(panels) Appends an array of panels
    * @method addLink(link) Adds a [dashboard link](https://grafana.com/docs/grafana/latest/linking/dashboard-links/)
+   * @method addDashboardLinks(dashboardLink) Adds an array of [dashboard links](https://grafana.com/docs/grafana/latest/linking/dashboard-links/)
    * @method addRequired(type, name, id, version)
    * @method addInput(name, label, type, pluginId, pluginName, description, value)
    * @method addRow(row) Adds a row. This is the legacy row concept from Grafana < 5, when rows were needed for layout. Rows should now be added via `addPanel`.
@@ -149,6 +150,7 @@ local timepickerlib = import 'timepicker.libsonnet';
     addLink(link):: self {
       links+: [link],
     },
+    addDashboardLinks(dashboardLinks):: std.foldl(function(d, t) d.addLink(t), dashboardLinks, self),
     required:: [],
     __requires: it.required,
     addRequired(type, name, id, version):: self {

--- a/grafonnet/dashboard.libsonnet
+++ b/grafonnet/dashboard.libsonnet
@@ -27,7 +27,7 @@ local timepickerlib = import 'timepicker.libsonnet';
    * @method addPanel(panel,gridPos) Appends a panel, with an optional grid position in grid coordinates, e.g. `gridPos={'x':0, 'y':0, 'w':12, 'h': 9}`
    * @method addPanels(panels) Appends an array of panels
    * @method addLink(link) Adds a [dashboard link](https://grafana.com/docs/grafana/latest/linking/dashboard-links/)
-   * @method addDashboardLinks(dashboardLink) Adds an array of [dashboard links](https://grafana.com/docs/grafana/latest/linking/dashboard-links/)
+   * @method addLinks(dashboardLink) Adds an array of [dashboard links](https://grafana.com/docs/grafana/latest/linking/dashboard-links/)
    * @method addRequired(type, name, id, version)
    * @method addInput(name, label, type, pluginId, pluginName, description, value)
    * @method addRow(row) Adds a row. This is the legacy row concept from Grafana < 5, when rows were needed for layout. Rows should now be added via `addPanel`.
@@ -150,7 +150,7 @@ local timepickerlib = import 'timepicker.libsonnet';
     addLink(link):: self {
       links+: [link],
     },
-    addDashboardLinks(dashboardLinks):: std.foldl(function(d, t) d.addLink(t), dashboardLinks, self),
+    addLinks(dashboardLinks):: std.foldl(function(d, t) d.addLink(t), dashboardLinks, self),
     required:: [],
     __requires: it.required,
     addRequired(type, name, id, version):: self {

--- a/tests/dashboards/adds.jsonnet
+++ b/tests/dashboards/adds.jsonnet
@@ -1,6 +1,8 @@
 local grafana = import 'grafonnet/grafana.libsonnet';
 local dashboard = grafana.dashboard;
 local row = grafana.row;
+local link = grafana.link;
+
 
 [
   dashboard.new('test')
@@ -13,7 +15,8 @@ local row = grafana.row;
   .addAnnotation('bar')
   .addAnnotations(['foo2', 'bar2'])
   .addLink('foolinks')
-  .addLink('barlinks'),
+  .addLink('barlinks')
+  .addDashboardLinks([link.dashboards('foo', ['foo', 'bar']), link.dashboards('bar', ['foo', 'bar'])]),
   dashboard.new('test2')
   .addPanel(row.new(title='id0'), { x: 14, y: 42, w: 33, h: 26 })
   .addPanel(row.new(title='id1'), { x: 24, y: 52, w: 43, h: 36 })

--- a/tests/dashboards/adds.jsonnet
+++ b/tests/dashboards/adds.jsonnet
@@ -16,7 +16,7 @@ local link = grafana.link;
   .addAnnotations(['foo2', 'bar2'])
   .addLink('foolinks')
   .addLink('barlinks')
-  .addDashboardLinks([link.dashboards('foo', ['foo', 'bar']), link.dashboards('bar', ['foo', 'bar'])]),
+  .addLinks([link.dashboards('foo', ['foo', 'bar']), link.dashboards('bar', ['foo', 'bar'])]),
   dashboard.new('test2')
   .addPanel(row.new(title='id0'), { x: 14, y: 42, w: 33, h: 26 })
   .addPanel(row.new(title='id1'), { x: 24, y: 52, w: 43, h: 36 })

--- a/tests/dashboards/adds_compiled.json
+++ b/tests/dashboards/adds_compiled.json
@@ -17,7 +17,35 @@
       "id": null,
       "links": [
          "foolinks",
-         "barlinks"
+         "barlinks",
+         {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": false,
+            "keepTime": false,
+            "tags": [
+               "foo",
+               "bar"
+            ],
+            "targetBlank": false,
+            "title": "foo",
+            "type": "dashboards",
+            "url": ""
+         },
+         {
+            "asDropdown": true,
+            "icon": "external link",
+            "includeVars": false,
+            "keepTime": false,
+            "tags": [
+               "foo",
+               "bar"
+            ],
+            "targetBlank": false,
+            "title": "bar",
+            "type": "dashboards",
+            "url": ""
+         }
       ],
       "refresh": "",
       "rows": [


### PR DESCRIPTION
Extend `dashboard.libsonnet` to support adding multiple Dashboard Links.