### PR TITLE
Add fillGradient param to graphPanel

### DIFF
--- a/examples/jvm_compiled.json
+++ b/examples/jvm_compiled.json
@@ -441,6 +441,7 @@
                "datasource": "-- Mixed --",
                "decimals": 2,
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 6,
                "legend": {
@@ -541,6 +542,7 @@
                "datasource": "-- Mixed --",
                "decimals": 2,
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 7,
                "legend": {
@@ -655,6 +657,7 @@
                "datasource": "-- Mixed --",
                "decimals": 2,
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 8,
                "legend": {
@@ -770,6 +773,7 @@
                "datasource": "-- Mixed --",
                "decimals": 2,
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 9,
                "legend": {
@@ -855,6 +859,7 @@
                "datasource": "-- Mixed --",
                "decimals": 2,
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 10,
                "legend": {
@@ -954,6 +959,7 @@
                "datasource": "-- Mixed --",
                "decimals": 2,
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 11,
                "legend": {
@@ -1071,6 +1077,7 @@
                "datasource": "-- Mixed --",
                "decimals": 2,
                "fill": 0,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 12,
                "legend": {

--- a/examples/k8s_cluster_summary_compiled.json
+++ b/examples/k8s_cluster_summary_compiled.json
@@ -686,6 +686,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 10,
                "legend": {
@@ -780,6 +781,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 11,
                "legend": {
@@ -874,6 +876,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 12,
                "legend": {
@@ -968,6 +971,7 @@
                "dashes": false,
                "datasource": "$datasource",
                "fill": 1,
+               "fillGradient": 0,
                "gridPos": { },
                "id": 13,
                "legend": {

--- a/examples/prometheus_compiled.json
+++ b/examples/prometheus_compiled.json
@@ -184,6 +184,7 @@
          "dashes": false,
          "datasource": "Prometheus",
          "fill": 1,
+         "fillGradient": 0,
          "gridPos": {
             "h": 8,
             "w": 7,

--- a/grafonnet/graph_panel.libsonnet
+++ b/grafonnet/graph_panel.libsonnet
@@ -10,6 +10,7 @@
    * @param span (optional) Width of the panel
    * @param datasource (optional) Datasource
    * @param fill (default `1`) , integer from 0 to 10
+   * @param fillGradient (default `0`) , integer from 0 to 10
    * @param linewidth (default `1`) Line Width, integer from 0 to 10
    * @param decimals (optional) Override automatic decimal precision for legend and tooltip. If null, not added to the json output.
    * @param decimalsY1 (optional) Override automatic decimal precision for the first Y axis. If null, use decimals parameter.
@@ -68,6 +69,7 @@
     title,
     span=null,
     fill=1,
+    fillGradient=0,
     linewidth=1,
     decimals=null,
     decimalsY1=null,
@@ -166,6 +168,7 @@
     },
     lines: lines,
     fill: fill,
+    fillGradient: fillGradient,
     linewidth: linewidth,
     dashes: dashes,
     dashLength: 10,

--- a/tests/graph_panel/test.jsonnet
+++ b/tests/graph_panel/test.jsonnet
@@ -21,6 +21,7 @@ local graphPanel = grafana.graphPanel;
     labelY2='labelY2',
     lines=false,
     fill=2,
+    fillGradient=1,
     linewidth=2,
     nullPointMode='nullAsZero',
     points=true,

--- a/tests/graph_panel/test_compiled.json
+++ b/tests/graph_panel/test_compiled.json
@@ -8,6 +8,7 @@
       "decimals": 2,
       "description": "description",
       "fill": 2,
+      "fillGradient": 1,
       "height": "2011px",
       "legend": {
          "alignAsTable": true,
@@ -114,6 +115,7 @@
       "dashes": false,
       "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "legend": {
          "alignAsTable": false,
          "avg": false,
@@ -203,6 +205,7 @@
       "dashes": false,
       "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "legend": {
          "alignAsTable": false,
          "avg": false,
@@ -277,6 +280,7 @@
       "dashes": false,
       "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "legend": {
          "alignAsTable": false,
          "avg": false,
@@ -348,6 +352,7 @@
       "datasource": null,
       "decimals": 2,
       "fill": 1,
+      "fillGradient": 0,
       "legend": {
          "alignAsTable": false,
          "avg": false,
@@ -419,6 +424,7 @@
       "dashes": false,
       "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "legend": {
          "alignAsTable": false,
          "avg": false,
@@ -489,6 +495,7 @@
       "dashes": false,
       "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "legend": {
          "alignAsTable": false,
          "avg": false,
@@ -561,6 +568,7 @@
       "dashes": false,
       "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "legend": {
          "alignAsTable": false,
          "avg": false,
@@ -633,6 +641,7 @@
       "dashes": false,
       "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "legend": {
          "alignAsTable": false,
          "avg": false,
@@ -706,6 +715,7 @@
       "dashes": false,
       "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "legend": {
          "alignAsTable": false,
          "avg": false,
@@ -785,6 +795,7 @@
       "dashes": false,
       "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "legend": {
          "alignAsTable": true,
          "avg": false,
@@ -857,6 +868,7 @@
       "dashes": false,
       "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "legend": {
          "alignAsTable": false,
          "avg": false,
@@ -926,6 +938,7 @@
       "dashes": false,
       "datasource": null,
       "fill": 1,
+      "fillGradient": 0,
       "legend": {
          "alignAsTable": false,
          "avg": false,


### PR DESCRIPTION
This PR adds graph panel support for `fill gradient` display option available since Grafana 6.3.

[desplay-options](https://grafana.com/docs/grafana/latest/panels/visualizations/graph-panel/#display-options)
[What is new in 6.3 > graph gradients](https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v6-3/#graph-gradients)