### PR TITLE
Add support for PostgreSQL target

### DIFF
--- a/grafonnet/grafana.libsonnet
+++ b/grafonnet/grafana.libsonnet
@@ -23,6 +23,7 @@
   heatmapPanel:: import 'heatmap_panel.libsonnet',
   dashlist:: import 'dashlist.libsonnet',
   pluginlist:: import 'pluginlist.libsonnet',
+  postgresql:: import 'postgresql.libsonnet',
   gauge:: error 'gauge is removed, migrate to gaugePanel',
   gaugePanel:: import 'gauge_panel.libsonnet',
   barGaugePanel:: import 'bar_gauge_panel.libsonnet',

--- a/grafonnet/postgresql.libsonnet
+++ b/grafonnet/postgresql.libsonnet
@@ -5,15 +5,18 @@
    * @name postgresql.target
    *
    * @param datasource (optional) Data source name.
+   * @param format (default `'time_series'`) Format options: `'table'` or `'time_series'`.
    * @param rawSql The raw query should at minimum have `ORDER BY` time and a filter(`WHERE`) on the returned time range.
    *
    * @return Panel target
    */
   target(
     datasource=null,
+    format='time_series',
     rawSql,
   ):: {
     [if datasource != null then 'datasource']: datasource,
+    format: format,
     rawSql: rawSql,
     rawQuery: true,
   },

--- a/grafonnet/postgresql.libsonnet
+++ b/grafonnet/postgresql.libsonnet
@@ -1,0 +1,20 @@
+{
+  /**
+   * Creates a [PostgreSQL target](https://grafana.com/docs/grafana/latest/datasources/postgres/)
+   *
+   * @name postgresql.target
+   *
+   * @param datasource (optional) Data source name.
+   * @param rawSql The raw query should at minimum have `ORDER BY` time and a filter(`WHERE`) on the returned time range.
+   *
+   * @return Panel target
+   */
+  target(
+    datasource=null,
+    rawSql,
+  ):: {
+    [if datasource != null then 'datasource']: datasource,
+    rawSql: rawSql,
+    rawQuery: true,
+  },
+}


### PR DESCRIPTION
- Add `postgresql.target` to support targets with PostgreSQL as data source https://grafana.com/docs/grafana/latest/datasources/postgres/