### PR TITLE
make maxDatapoints for singleStat configurable

### DIFF
--- a/grafonnet/singlestat.libsonnet
+++ b/grafonnet/singlestat.libsonnet
@@ -42,6 +42,7 @@
    * @param links (optional)
    * @param tableColumn (default `''`)
    * @param maxPerRow (optional)
+   * @param maxDataPoints (default `100`)
    *
    * @method addTarget(target) Adds a target object.
    */
@@ -100,6 +101,7 @@
     links=[],
     tableColumn='',
     maxPerRow=null,
+    maxDataPoints=100,
   )::
     {
       [if height != null then 'height']: height,
@@ -116,7 +118,7 @@
       ],
       links: links,
       [if decimals != null then 'decimals']: decimals,
-      maxDataPoints: 100,
+      maxDataPoints: maxDataPoints,
       interval: interval,
       cacheTimeout: null,
       format: format,

--- a/tests/singlestat/test.jsonnet
+++ b/tests/singlestat/test.jsonnet
@@ -13,6 +13,7 @@ local singlestat = grafana.singlestat;
     'adv',
     format='s',
     interval='10s',
+    maxDataPoints=1000,
     repeatDirection='v',
     height='42px',
     prefixFontSize='10%',

--- a/tests/singlestat/test_compiled.json
+++ b/tests/singlestat/test_compiled.json
@@ -39,7 +39,7 @@
             "value": 2
          }
       ],
-      "maxDataPoints": 100,
+      "maxDataPoints": 1000,
       "minSpan": 6,
       "nullPointMode": "connected",
       "nullText": null,


### PR DESCRIPTION
# Making MaxDataPoints an input to the SingleStat panel

For large dashboard time ranges (e.g. 5 days) the minInterval setting is ignored and range/maxDataPoints is used to construct the `step` parameter in queries.

This can cause Prometheus (based on when the query is issued) to miss data points for metrics that have very few data points (e.g. 1 per hour). and Display N/A instead of actual data.

This PR preserves the the old hardcoded value (100) as a default to be non-breaking, but offers the option to change this value for users who need it (e.g. use-case above).

