### PR TITLE
Add maxDataPoints to heatmap

### DIFF
--- a/grafonnet/heatmap_panel.libsonnet
+++ b/grafonnet/heatmap_panel.libsonnet
@@ -42,6 +42,7 @@
    * @param yBucketBound (default `'auto'`) Which bound ('lower' or 'upper') of the bucket to use
    * @param yBucketNumber (optional) Number of buckets for the Y axis
    * @param yBucketSize (optional) Size of Y axis buckets. Has priority over yBucketNumber
+   * @param maxDataPoints (optional) The maximum data points per series. Used directly by some data sources and used in calculation of auto interval. With streaming data this value is used for the rolling buffer.
    *
    * @method addTarget(target) Adds a target object.
    * @method addTargets(targets) Adds an array of targets.
@@ -83,7 +84,7 @@
     yBucketBound='auto',
     yBucketNumber=null,
     yBucketSize=null,
-
+    maxDataPoints=null,
   ):: {
     title: title,
     type: 'heatmap',
@@ -135,6 +136,7 @@
     yBucketBound: yBucketBound,
     [if dataFormat == 'timeseries' then 'yBucketNumber']: yBucketNumber,
     [if dataFormat == 'timeseries' then 'yBucketSize']: yBucketSize,
+    [if maxDataPoints != null then 'maxDataPoints']: maxDataPoints,
 
     _nextTarget:: 0,
     addTarget(target):: self {

--- a/tests/heatmap_panel/test.jsonnet
+++ b/tests/heatmap_panel/test.jsonnet
@@ -43,6 +43,7 @@ local heatmapPanel = grafana.heatmapPanel;
       yBucketBound='lower',
       yBucketNumber=4,
       yBucketSize=5,
+      maxDataPoints=50,
     ),
 
   advanced_tsbuckets:
@@ -76,6 +77,7 @@ local heatmapPanel = grafana.heatmapPanel;
       yBucketBound='auto',
       yBucketNumber=1,
       yBucketSize=2,
+      maxDataPoints=50,
     ),
 
   basic_color_opacity:

--- a/tests/heatmap_panel/test_compiled.json
+++ b/tests/heatmap_panel/test_compiled.json
@@ -21,6 +21,7 @@
       "legend": {
          "show": true
       },
+      "maxDataPoints": 50,
       "minSpan": 6,
       "repeat": "PROMETHEUS_DS",
       "repeatDirection": "h",
@@ -70,6 +71,7 @@
       "legend": {
          "show": false
       },
+      "maxDataPoints": 50,
       "repeat": "PROMETHEUS_DS",
       "repeatDirection": "v",
       "title": "advanced tsbuckets test",


### PR DESCRIPTION
Another small PR to add `maxDataPoints` to the heatmap panel, as its often used to make the heatmap manageable over larger timeranges.