### PR TITLE
Documentation: Adds community plugin for bigquery panel

### DIFF
--- a/docs/community-plugins.md
+++ b/docs/community-plugins.md
@@ -19,3 +19,4 @@ please submit a pull request to get it added to this list.
 * [Status panel (by Vonage)](https://grafana.com/grafana/plugins/vonage-status-panel) template plugin: [link](https://github.com/DifferentialOrange/grafonnet-status-panel).
 * [Statusmap panel (by Flant)](https://grafana.com/grafana/plugins/flant-statusmap-panel) template plugin: [link](https://github.com/blablacar/grafonnet-lib-plugins).
 * [Polystat panel (by Grafana Labs)](https://grafana.com/grafana/plugins/grafana-polystat-panel) template plugin: [link](https://github.com/thelastpickle/grafonnet-polystat-panel).
+* [Bigquery panel (by DoiT International)](https://grafana.com/grafana/plugins/doitintl-bigquery-datasource) template plugin: [link](https://github.com/gojekfarm/grafonnet-bigquery-panel).


### PR DESCRIPTION
This is in reference to the PR: https://github.com/grafana/grafonnet-lib/pull/256 
We were asked to host the plugin on our repo and add it as a community plugin.