### PR TITLE
Add queryMode and logGroupNames to cloudwatch target

### DIFF
--- a/grafonnet/cloudwatch.libsonnet
+++ b/grafonnet/cloudwatch.libsonnet
@@ -5,8 +5,8 @@
    * @name cloudwatch.target
    *
    * @param region
-   * @param namespace
-   * @param metric
+   * @param namespace (optional)
+   * @param metric (optional)
    * @param datasource (optional)
    * @param statistic (default: `'Average'`)
    * @param alias (optional)
@@ -16,14 +16,16 @@
    * @param id (optional)
    * @param expression (optional)
    * @param hide (optional)
+   * @param queryMode (optional)
+   * @param logGroupNames (optional)
 
    * @return Panel target
    */
 
   target(
     region,
-    namespace,
-    metric,
+    namespace=null,
+    metric=null,
     datasource=null,
     statistic='Average',
     alias=null,
@@ -32,11 +34,13 @@
     dimensions={},
     id=null,
     expression=null,
-    hide=null
+    hide=null,
+    queryMode=null,
+    logGroupNames=null
   ):: {
     region: region,
-    namespace: namespace,
-    metricName: metric,
+    [if namespace != null then 'namespace']: namespace,
+    [if metric != null then 'metricName']: metric,
     [if datasource != null then 'datasource']: datasource,
     statistics: [statistic],
     [if alias != null then 'alias']: alias,
@@ -46,6 +50,7 @@
     [if id != null then 'id']: id,
     [if expression != null then 'expression']: expression,
     [if hide != null then 'hide']: hide,
-
+    [if queryMode != null then 'queryMode']: queryMode,
+    [if logGroupNames != null then 'logGroupNames']: logGroupNames,
   },
 }


### PR DESCRIPTION
Add queryMode and logGroupNames to cloudwatch target to allow search on cloudwatch logs (grafana 7).

With Grafana 7 we are now able to query the logs and display the result in a table pannel. We need some new fields:
- queryMode (Metrics/Logs)
- logGroupNames (needed when we are in Logs queryMode)

We also need fields like "namespace" and "metric" to become optional as we don't need them anymore when we are in Logs queryMode.