### PR TITLE
Add color scheme support for statPanels for Grafana 7

### DIFF
--- a/grafonnet/stat_panel.libsonnet
+++ b/grafonnet/stat_panel.libsonnet
@@ -17,6 +17,7 @@
    * @param graphMode (default `'area'`) 'none' or 'area' to enable sparkline mode.
    * @param justifyMode (default `'auto'`) 'auto' or 'center'.
    * @param unit (default `'none'`) Panel unit field option.
+   * @param colorScheme (optional) `'fixed'` (or color name e.g. `'yellow'`), `'threshold'`, `'classic-palette'`, `'continuous-GrYlRd'`, `'continuous-RdYlGr'` or `'continuous-BlYlRd'`
    * @param min (optional) Leave empty to calculate based on all values.
    * @param max (optional) Leave empty to calculate based on all values.
    * @param decimals (optional) Number of decimal places to show.
@@ -53,6 +54,7 @@
     colorMode='value',
     graphMode='area',
     justifyMode='auto',
+    colorScheme=null,
     unit='none',
     min=null,
     max=null,
@@ -115,6 +117,9 @@
       fieldConfig: {
         defaults: {
           unit: unit,
+          [if colorScheme != null then 'color']: {
+            mode: colorScheme
+          },
           [if min != null then 'min']: min,
           [if max != null then 'max']: max,
           [if decimals != null then 'decimals']: decimals,

--- a/tests/stat_panel/test.jsonnet
+++ b/tests/stat_panel/test.jsonnet
@@ -14,6 +14,7 @@ local stat = grafana.statPanel;
       graphMode='area',
       thresholdsMode='percentage',
       timeFrom='1h',
+      colorScheme='classic-palette'
     ),
   links:
     stat.new('links')

--- a/tests/stat_panel/test_compiled.json
+++ b/tests/stat_panel/test_compiled.json
@@ -4,6 +4,9 @@
       "description": "An advanced stat panel configuration",
       "fieldConfig": {
          "defaults": {
+            "color": {
+               "mode": "classic-palette"
+            },
             "links": [ ],
             "mappings": [ ],
             "thresholds": {


### PR DESCRIPTION
Add a parameter to change the scheme color on the field section for stat panels

https://grafana.com/docs/grafana/latest/panels/field-options/standard-field-options/#color-scheme

```
@param colorScheme (optional) `'fixed'` (or color name e.g. `'yellow'`), `'threshold'`, `'classic-palette'`, `'continuous-GrYlRd'`, `'continuous-RdYlGr'` or `'continuous-BlYlRd'`
```