### PR TITLE
Fix broken usage link

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,4 +28,4 @@ jb init
 jb install https://github.com/grafana/grafonnet-lib/grafonnet
 ```
 
-See the [Usage](usage) page for next steps.
+See the [Usage](usage.md) page for next steps.


### PR DESCRIPTION
# Problem

Clicking on the "Usage" link in https://grafana.github.io/grafonnet-lib/getting-started/ leads you to https://grafana.github.io/grafonnet-lib/getting-started/usage, which is broken. It should lead to https://grafana.github.io/grafonnet-lib/usage/ instead.

# Solution

According to https://www.mkdocs.org/user-guide/writing-your-docs/#linking-to-pages, we can link to pages by using relative links to the files.