### PR TITLE
Fix Usage broken link in mkdocs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,4 +28,4 @@ jb init
 jb install https://github.com/grafana/grafonnet-lib/grafonnet
 ```
 
-See the [Usage](usage) page for next steps.
+See the [Usage](usage.md) page for next steps.


### PR DESCRIPTION
Hello, I noticed that the link towards Usage in: https://grafana.github.io/grafonnet-lib/getting-started/ is broken.
Following this doc: https://www.mkdocs.org/user-guide/writing-your-docs/#linking-to-pages it seems that it was just missing the .md extension.

Tested locally using `mkdocs serve`.
