### PR TITLE
Fix links to datasource docs

### DIFF
--- a/grafonnet/cloudmonitoring.libsonnet
+++ b/grafonnet/cloudmonitoring.libsonnet
@@ -1,6 +1,6 @@
 {
   /**
-   * Creates a [Google Cloud Monitoring target](https://grafana.com/docs/grafana/latest/datasources/cloudmonitoring/)
+   * Creates a [Google Cloud Monitoring target](https://grafana.com/docs/grafana/latest/datasources/google-cloud-monitoring/)
    *
    * @name cloudmonitoring.target
    *

--- a/grafonnet/cloudwatch.libsonnet
+++ b/grafonnet/cloudwatch.libsonnet
@@ -1,6 +1,6 @@
 {
   /**
-   * Creates a [CloudWatch target](https://grafana.com/docs/grafana/latest/features/datasources/cloudwatch/)
+   * Creates a [CloudWatch target](https://grafana.com/docs/grafana/latest/datasources/cloudwatch/)
    *
    * @name cloudwatch.target
    *

--- a/grafonnet/elasticsearch.libsonnet
+++ b/grafonnet/elasticsearch.libsonnet
@@ -1,6 +1,6 @@
 {
   /**
-   * Creates an [Elasticsearch target](https://grafana.com/docs/grafana/latest/features/datasources/elasticsearch/)
+   * Creates an [Elasticsearch target](https://grafana.com/docs/grafana/latest/datasources/elasticsearch/)
    *
    * @name elasticsearch.target
    *

--- a/grafonnet/graphite.libsonnet
+++ b/grafonnet/graphite.libsonnet
@@ -1,6 +1,6 @@
 {
   /**
-   * Creates a [Graphite target](https://grafana.com/docs/grafana/latest/features/datasources/graphite/)
+   * Creates a [Graphite target](https://grafana.com/docs/grafana/latest/datasources/graphite/)
    *
    * @name graphite.target
    *

--- a/grafonnet/influxdb.libsonnet
+++ b/grafonnet/influxdb.libsonnet
@@ -1,6 +1,6 @@
 {
   /**
-   * Creates an [InfluxDB target](https://grafana.com/docs/grafana/latest/features/datasources/influxdb/)
+   * Creates an [InfluxDB target](https://grafana.com/docs/grafana/latest/datasources/influxdb/)
    *
    * @name influxdb.target
    *

--- a/grafonnet/loki.libsonnet
+++ b/grafonnet/loki.libsonnet
@@ -1,6 +1,6 @@
 {
   /**
-   * Creates a [Loki target](https://grafana.com/docs/grafana/latest/features/datasources/loki/)
+   * Creates a [Loki target](https://grafana.com/docs/grafana/latest/datasources/loki/)
    *
    * @name loki.target
    *

--- a/grafonnet/prometheus.libsonnet
+++ b/grafonnet/prometheus.libsonnet
@@ -1,6 +1,6 @@
 {
   /**
-   * Creates a [Prometheus target](https://grafana.com/docs/grafana/latest/features/datasources/prometheus/)
+   * Creates a [Prometheus target](https://grafana.com/docs/grafana/latest/datasources/prometheus/)
    * to be added to panels.
    *
    * @name prometheus.target


### PR DESCRIPTION
These links went to pages for Grafana 7.5. Update them to the latest URLs.

This is probably a bug in the docs website tbh.