### PR TITLE
Change the cloudwatch target's default period to 'auto'

### DIFF
--- a/grafonnet/cloudwatch.libsonnet
+++ b/grafonnet/cloudwatch.libsonnet
@@ -11,7 +11,7 @@
    * @param statistic (default: `'Average'`)
    * @param alias (optional)
    * @param highResolution (default: `false`)
-   * @param period (default: `'1m'`)
+   * @param period (default: `'auto'`)
    * @param dimensions (optional)
    * @param id (optional)
    * @param expression (optional)
@@ -28,7 +28,7 @@
     statistic='Average',
     alias=null,
     highResolution=false,
-    period='1m',
+    period='auto',
     dimensions={},
     id=null,
     expression=null,

--- a/tests/cloudwatch/test_compiled.json
+++ b/tests/cloudwatch/test_compiled.json
@@ -9,7 +9,7 @@
       "highResolution": false,
       "metricName": "RequestCountPerTarget",
       "namespace": "AWS/ApplicationELB",
-      "period": "1m",
+      "period": "auto",
       "region": "eu-west-1",
       "statistics": [
          "Sum"
@@ -20,7 +20,7 @@
       "highResolution": false,
       "metricName": "RequestCountPerTarget",
       "namespace": "AWS/ApplicationELB",
-      "period": "1m",
+      "period": "auto",
       "region": "eu-west-1",
       "statistics": [
          "Average"


### PR DESCRIPTION
A default of 1m causes problems for metrics which are recorded infrequently
(e.g. S3) and for visualising long time ranges.

Fixes #345 