### PR TITLE
Fix dead links for heatmap and table panels

### DIFF
--- a/grafonnet/heatmap_panel.libsonnet
+++ b/grafonnet/heatmap_panel.libsonnet
@@ -1,6 +1,6 @@
 {
   /**
-   * Creates a [heatmap panel](https://grafana.com/docs/grafana/latest/panels/visualizations/heatmap/).
+   * Creates a [heatmap panel](https://grafana.com/docs/grafana/latest/visualizations/heatmap/).
    * Requires the heatmap panel plugin in Grafana, which is built-in.
    *
    * @name heatmapPanel.new

--- a/grafonnet/table_panel.libsonnet
+++ b/grafonnet/table_panel.libsonnet
@@ -1,6 +1,6 @@
 {
   /**
-   * Creates a [table panel](https://grafana.com/docs/grafana/latest/panels/visualizations/table-panel/) that can be added in a row.
+   * Creates a [table panel](https://grafana.com/docs/grafana/latest/visualizations/table/) that can be added in a row.
    * It requires the table panel plugin in grafana, which is built-in.
    *
    * @name table.new


### PR DESCRIPTION
I tried to fix the dead links with what I assume were the intended links.

```bash
# Old
https://grafana.com/docs/grafana/latest/panels/visualizations/heatmap/

# New
https://grafana.com/docs/grafana/latest/visualizations/heatmap/
```

```bash
# Old
https://grafana.com/docs/grafana/latest/panels/visualizations/table-panel/

# New
https://grafana.com/docs/grafana/latest/visualizations/table/
```