### PR TITLE
addTransformation to table in grafonnet-7.0

### DIFF
--- a/grafonnet-7.0/panel/table.libsonnet
+++ b/grafonnet-7.0/panel/table.libsonnet
@@ -134,12 +134,12 @@
       id=null,
       options=null
     ):: self {}
-          + { transformations+: [
-              {
-                [if id != null then 'id']: id,
-                [if options != null then 'options']: options,
-              },
-          ] },
+        + { transformations+: [
+          {
+            [if id != null then 'id']: id,
+            [if options != null then 'options']: options,
+          },
+        ] },
 
   },
 }

--- a/grafonnet-7.0/panel/table.libsonnet
+++ b/grafonnet-7.0/panel/table.libsonnet
@@ -130,5 +130,16 @@
           target,
         ] },
 
+    addTransformation(
+      id=null,
+      options=null
+    ):: self {}
+          + { transformations+: [
+              {
+                [if id != null then 'id']: id,
+                [if options != null then 'options']: options,
+              },
+          ] },
+
   },
 }


### PR DESCRIPTION
table (new) in grafonnet-7.0 is missing addTransformation function from table_panel (old) in grafonnet
 
I have a case where I want to use the addOverride function in combination with the addTransformation for a table panel.
 
As for now:
 
- [table_panel (old, grafonnet) supports addTransformation](https://github.com/grafana/grafonnet-lib/blob/master/grafonnet/table_panel.libsonnet#L86-L89)
-  [table (new, grafonnet-7.0) supports addOverride](https://github.com/grafana/grafonnet-lib/blob/master/grafonnet-7.0/panel/table.libsonnet#L104-L113)
 
Suggested change:
 
- add the function `addTransformation` to table (new) -> grafonnet-7.0/panel/table.libsonnet
 
The new addTransformation functions is composed of [transformation.libsonnet](https://github.com/grafana/grafonnet-lib/blob/master/grafonnet/transformation.libsonnet) and the [addTransformation function in table_panel.libsonnet L86-L89](https://github.com/grafana/grafonnet-lib/blob/master/grafonnet/table_panel.libsonnet#L86-L89). I tried following the same pattern as for addOverride and addThresholdStep functions already present in the file.